### PR TITLE
Docs: update `getting-started/README` test output

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -146,7 +146,9 @@ Compiling...
 Compiled 2 contracts successfully
 
 
-  Contract: Greeter
+  Greeter
+Deploying a Greeter with greeting: Hello, world!
+Changing greeting from 'Hello, world!' to 'Hola, mundo!'
     ✓ Should return the new greeting once it's changed (762ms)
 
   1 passing (762ms)


### PR DESCRIPTION
- Aligns "Getting Started" doc output with latest release output.