### PR TITLE
Fix: destructure BRE require in `sample-script`

### DIFF
--- a/packages/buidler-core/sample-project/scripts/sample-script.js
+++ b/packages/buidler-core/sample-project/scripts/sample-script.js
@@ -1,14 +1,14 @@
-// We require the Buidler Runtime Environment explicitly here. This is optional 
+// We require the Buidler Runtime Environment and Ethers.js explicitly here. This is optional
 // but useful for running the script in a standalone fashion through `node <script>`.
 // When running the script with `buidler run <script>` you'll find the Buidler
 // Runtime Environment's members available in the global scope.
-const bre = require("@nomiclabs/buidler");
+const { run, ethers } = require("@nomiclabs/buidler");
 
 async function main() {
   // Buidler always runs the compile task when running scripts through it. 
   // If this runs in a standalone fashion you may want to call compile manually 
   // to make sure everything is compiled
-  // await bre.run('compile');
+  // await run('compile');
 
   // We get the contract to deploy
   const Greeter = await ethers.getContractFactory("Greeter");


### PR DESCRIPTION
- Enables running `sample-script` as a standalone node script