### PR TITLE
Make buidler-evm's tracing compatible with mapping function arguments.

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
@@ -456,7 +456,8 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
     const typename = param.typeName;
     if (
       typename.nodeType === "ArrayTypeName" ||
-      typename.nodeType === "FunctionTypeName"
+      typename.nodeType === "FunctionTypeName" ||
+      typename.nodeType === "Mapping"
     ) {
       paramTypes.push(typename.typeDescriptions.typeString);
       continue;


### PR DESCRIPTION
`typeDescriptions.typeString` should be correct for mapping types as well!