### PR TITLE
fix: do not prompt for consent in ci environments

### DIFF
--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -18,6 +18,7 @@ import { isCwdInsideProject } from "../core/project-structure";
 import { Environment } from "../core/runtime-environment";
 import { loadTsNode, willRunWithTypescript } from "../core/typescript-support";
 import { Reporter } from "../sentry/reporter";
+import { isRunningOnCiServer } from "../util/ci-detection";
 import {
   hasConsentedTelemetry,
   writeTelemetryConsent,
@@ -119,7 +120,11 @@ async function main() {
     let telemetryConsent = hasConsentedTelemetry();
 
     const isHelpCommand = hardhatArguments.help || taskName === TASK_HELP;
-    if (telemetryConsent === undefined && !isHelpCommand) {
+    if (
+      telemetryConsent === undefined &&
+      !isHelpCommand &&
+      !isRunningOnCiServer()
+    ) {
       telemetryConsent = await confirmTelemetryConsent();
       writeTelemetryConsent(telemetryConsent);
     }


### PR DESCRIPTION
There is already a check that disables telemetry inside of `analytics.ts`, however, the prompt is still shown. This is problematic in CI environments especially because there is currently no way to skip this check (e.g. with `--yes` // `--no`). As a result, CI currently gets stuck infinitely.