### PR TITLE
Export extended ethers Signer

### DIFF
--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -26,3 +26,5 @@ extendEnvironment((hre) => {
     };
   });
 });
+
+export { ExtendedEthersSigner as Signer } from "./types";

--- a/packages/hardhat-ethers/src/signer-with-address.ts
+++ b/packages/hardhat-ethers/src/signer-with-address.ts
@@ -1,6 +1,9 @@
 import { ethers } from "ethers";
 
-export class SignerWithAddress extends ethers.Signer {
+import { ExtendedEthersSigner } from "./types";
+
+export class SignerWithAddress extends ethers.Signer
+  implements ExtendedEthersSigner {
   public static async create(signer: ethers.Signer) {
     return new SignerWithAddress(await signer.getAddress(), signer);
   }

--- a/packages/hardhat-ethers/src/types.ts
+++ b/packages/hardhat-ethers/src/types.ts
@@ -1,0 +1,5 @@
+import type { ethers } from "ethers";
+
+export interface ExtendedEthersSigner extends ethers.Signer {
+  address: string;
+}


### PR DESCRIPTION
Using the extended signer in a test is cumbersome because you need to do this:

```typescript
import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";

describe(() => {
  let signers: SignerWithAddress[]

  beforeEach(async () => {
    signers = await ethers.getSigners()
```

to be able to type-check something like `signers[0].address` .

With this PR, the import can be replaced with:

```typescript
import { Signer } from "@nomiclabs/hardhat-ethers";
```