### PR TITLE
feat: allow to disable collection of telemetry data through config

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -9,11 +9,12 @@ The entirety of your Hardhat setup (i.e. your config, plugins and custom tasks) 
 
 To set up your config, you have to export an object from `hardhat.config.js`.
 
-This object can have the following entries: `defaultNetwork`, [`networks`](#networks-configuration), [`solidity`](#solidity-configuration), and [`paths`](#path-configuration). For example:
+This object can have the following entries: `defaultNetwork`, `disableTelemetry` [`networks`](#networks-configuration), [`solidity`](#solidity-configuration), and [`paths`](#path-configuration). For example:
 
 ```js
 module.exports = {
   defaultNetwork: "rinkeby",
+  disableTelemetry: true,
   networks: {
     hardhat: {
     },

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -77,6 +77,7 @@ GLOBAL OPTIONS:
   --max-memory          The maximum amount of memory that Hardhat can use.
   --network             The network to connect to.
   --show-stack-traces   Show stack traces.
+  --disable-telemetry   Disable collection of telemetry data.
   --tsconfig            Reserved hardhat argument -- Has no effect.
   --verbose             Enables Hardhat verbose logging
   --version             Shows hardhat's version.

--- a/docs/guides/create-task.md
+++ b/docs/guides/create-task.md
@@ -88,6 +88,7 @@ GLOBAL OPTIONS:
   --help                Shows this message.
   --network             The network to connect to. (default: "hardhat")
   --show-stack-traces   Show stack traces.
+  --disable-telemetry   Disable collection of telemetry data.
   --version             Shows hardhat's version.
 
 

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -123,7 +123,9 @@ async function main() {
     if (
       telemetryConsent === undefined &&
       !isHelpCommand &&
-      !isRunningOnCiServer()
+      !isRunningOnCiServer() &&
+      !hardhatArguments.disableTelemetry &&
+      !config.disableTelemetry
     ) {
       telemetryConsent = await confirmTelemetryConsent();
       writeTelemetryConsent(telemetryConsent);

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -58,6 +58,7 @@ export function resolveConfig(
 
   return {
     ...userConfig,
+    disableTelemetry: userConfig.disableTelemetry ?? false,
     defaultNetwork: userConfig.defaultNetwork ?? defaultDefaultNetwork,
     paths: resolveProjectPaths(userConfigPath, userConfig.paths),
     networks: resolveNetworksConfig(userConfig.networks),

--- a/packages/hardhat-core/src/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-validation.ts
@@ -194,6 +194,7 @@ const SolidityConfig = t.union([t.string, SingleSolcConfig, MultiSolcConfig]);
 const HardhatConfig = t.type(
   {
     defaultNetwork: optional(t.string),
+    disableTelemetry: optional(t.boolean),
     networks: optional(Networks),
     paths: optional(ProjectPaths),
     solidity: optional(SolidityConfig),

--- a/packages/hardhat-core/src/internal/core/params/hardhat-params.ts
+++ b/packages/hardhat-core/src/internal/core/params/hardhat-params.ts
@@ -21,6 +21,15 @@ export const HARDHAT_PARAM_DEFINITIONS: HardhatParamDefinitions = {
     isOptional: true,
     isVariadic: false,
   },
+  disableTelemetry: {
+    name: "disableTelemetry",
+    defaultValue: false,
+    description: "Disable collection of telemetry data.",
+    type: types.boolean,
+    isFlag: true,
+    isOptional: true,
+    isVariadic: false,
+  },
   version: {
     name: "version",
     defaultValue: false,

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -206,6 +206,7 @@ export interface SolidityConfig {
 
 export interface HardhatUserConfig {
   defaultNetwork?: string;
+  disableTelemetry?: boolean;
   paths?: ProjectPathsUserConfig;
   networks?: NetworksUserConfig;
   solidity?: SolidityUserConfig;
@@ -214,6 +215,7 @@ export interface HardhatUserConfig {
 
 export interface HardhatConfig {
   defaultNetwork: string;
+  disableTelemetry: boolean;
   paths: ProjectPathsConfig;
   networks: NetworksConfig;
   solidity: SolidityConfig;

--- a/packages/hardhat-core/src/types/runtime.ts
+++ b/packages/hardhat-core/src/types/runtime.ts
@@ -159,6 +159,7 @@ export type ActionType<ArgsT extends TaskArguments> = (
 export interface HardhatArguments {
   network?: string;
   showStackTraces: boolean;
+  disableTelemetry: boolean;
   version: boolean;
   help: boolean;
   emoji: boolean;

--- a/packages/hardhat-core/test/internal/cli/ArgumentsParser.ts
+++ b/packages/hardhat-core/test/internal/cli/ArgumentsParser.ts
@@ -30,6 +30,7 @@ describe("ArgumentsParser", () => {
     argumentsParser = new ArgumentsParser();
     envArgs = {
       network: "test",
+      disableTelemetry: false,
       showStackTraces: false,
       version: false,
       help: false,

--- a/packages/hardhat-core/test/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-resolution.ts
@@ -36,6 +36,7 @@ describe("Config resolution", () => {
         assert.containsAllKeys(config.networks, ["localhost"]);
         assert.isUndefined(config.solidity.compilers[0]?.settings?.evmVersion);
         assert.equal(config.defaultNetwork, "hardhat");
+        assert.equal(config.disableTelemetry, false);
 
         const hardhatNetworkConfig: HardhatNetworkUserConfig = config.networks
           .hardhat as HardhatNetworkUserConfig;
@@ -51,6 +52,7 @@ describe("Config resolution", () => {
       beforeEach(() => {
         config = resolveConfig(__filename, {
           defaultNetwork: "custom",
+          disableTelemetry: true,
           networks: {
             custom: {
               url: "http://localhost:8545",
@@ -73,6 +75,7 @@ describe("Config resolution", () => {
         assert.equal(config.solidity.compilers[0].version, "0.5.15");
         assert.containsAllKeys(config.networks, ["localhost", "custom"]);
         assert.equal(config.defaultNetwork, "custom");
+        assert.equal(config.disableTelemetry, true);
       });
 
       it("should return the config merged ", () => {

--- a/packages/hardhat-core/test/internal/core/params/env-variables.ts
+++ b/packages/hardhat-core/test/internal/core/params/env-variables.ts
@@ -80,6 +80,7 @@ describe("getEnvVariablesMap", () => {
         network: "asd",
         emoji: false,
         help: true,
+        disableTelemetry: true,
         showStackTraces: true,
         version: false,
         verbose: true,

--- a/packages/hardhat-core/test/internal/core/runtime-environment.ts
+++ b/packages/hardhat-core/test/internal/core/runtime-environment.ts
@@ -28,6 +28,7 @@ import { useFixtureProject } from "../../helpers/project";
 describe("Environment", () => {
   const config: HardhatConfig = {
     defaultNetwork: "default",
+    disableTelemetry: false,
     networks: {
       localhost: {
         url: "http://localhosthost:8545",
@@ -70,6 +71,7 @@ describe("Environment", () => {
 
   const args: HardhatArguments = {
     network: "localhost",
+    disableTelemetry: false,
     showStackTraces: false,
     version: false,
     help: false,

--- a/packages/hardhat-core/test/internal/core/tasks/task-definitions.ts
+++ b/packages/hardhat-core/test/internal/core/tasks/task-definitions.ts
@@ -195,6 +195,7 @@ describe("SimpleTaskDefinition", () => {
         // added and not tested.
         const hardhatArgs: HardhatArguments = {
           showStackTraces: true,
+          disableTelemetry: false,
           network: "",
           version: false,
           emoji: false,


### PR DESCRIPTION
Currently, when running `hardhat` in a lerna setup and running e.g. `hardhat compile` in many packages at once, the prompt for consent silently fails but doesn't exit the process, thus leaving the user with no way to realize that something went wrong at all.

To fix this for them, the user then has to `cd` into one of the packages manually and run `hardhat compile` in there specifically to answer the consent prompt before being able to run it at the root of the `lerna` repository. This all obviously first requires them to realize what happened and why the previous command silently exited.

I am not sure what the best way to fix this is... I personally prefer not having prompts like this at all, because they are quite intrusive, or having a way to skip them through configuration in hardhat.config.js entirely.

This PR allows to skip it both through config and/or through a cli argument.