### PR TITLE
Fix telemetry consent prompt

### DIFF
--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -117,13 +117,14 @@ async function main() {
       showWarningIfNoSolidityConfig,
     });
 
-    let telemetryConsent = hasConsentedTelemetry();
+    let telemetryConsent: boolean | undefined = hasConsentedTelemetry();
 
     const isHelpCommand = hardhatArguments.help || taskName === TASK_HELP;
     if (
       telemetryConsent === undefined &&
       !isHelpCommand &&
-      !isRunningOnCiServer()
+      !isRunningOnCiServer() &&
+      process.stdout.isTTY === true
     ) {
       telemetryConsent = await confirmTelemetryConsent();
       writeTelemetryConsent(telemetryConsent);

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -127,7 +127,10 @@ async function main() {
       process.stdout.isTTY === true
     ) {
       telemetryConsent = await confirmTelemetryConsent();
-      writeTelemetryConsent(telemetryConsent);
+
+      if (telemetryConsent !== undefined) {
+        writeTelemetryConsent(telemetryConsent);
+      }
     }
 
     const analytics = await Analytics.getInstance(telemetryConsent);

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -136,7 +136,9 @@ async function main() {
     const analytics = await Analytics.getInstance(telemetryConsent);
 
     Reporter.setConfigPath(config.paths.configFile);
-    Reporter.setEnabled(true);
+    if (telemetryConsent === true) {
+      Reporter.setEnabled(true);
+    }
 
     const envExtenders = ctx.extendersManager.getExtenders();
     const taskDefinitions = ctx.tasksDSL.getTaskDefinitions();


### PR DESCRIPTION
This PR implements three changes to the telemetry consent prompt:

1. It doesn't show it if not running in an interactive terminal. When running hardhat from a script, it defaults to not reporting anything.
2. It adds a timeout to the prompt. If we don't get an answer in a short period of time, we don't report anything, nor store any consent value.
3. Don't enable the error reporting unless we have explicit consent from the user.