### PR TITLE
Warn against standalone types in hardhat-ethers type extensions.

### DIFF
--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -8,6 +8,8 @@ import type {
 import type { SignerWithAddress } from "./signer-with-address";
 
 declare module "hardhat/types/runtime" {
+  // Beware, adding new types to any hardhat type submodule is not a good practice in a Hardhat plugin.
+  // Doing so increases the risk of a type clash with another plugin.
   type Libraries = LibrariesT;
   type FactoryOptions = FactoryOptionsT;
 


### PR DESCRIPTION
This removes standalone types in `hardhat-ethers` type extensions.