### PR TITLE
Fix source name validation for names that start with '.'

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -926,7 +926,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     INVALID_SOURCE_NAME_RELATIVE_PATH: {
       number: 1001,
       message:
-        "Invalid source name %name%. Expected source name but found an absolute path.",
+        "Invalid source name %name%. Expected source name but found a relative path.",
       title: "Invalid source name: relative path",
       description: `A Solidity source name was expected, but a relative path was given.
       

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -21,7 +21,7 @@ export function validateSourceNameFormat(sourceName: string) {
     );
   }
 
-  if (sourceName.startsWith(".")) {
+  if (isExplicitRelativePath(sourceName)) {
     throw new HardhatError(
       ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_RELATIVE_PATH,
       {
@@ -160,6 +160,15 @@ export function normalizeSourceName(sourceName: string): string {
  */
 export function isAbsolutePathSourceName(sourceName: string): boolean {
   return path.isAbsolute(sourceName) || sourceName.startsWith("/");
+}
+
+/**
+ * This function returns true if the sourceName is a unix path that is based on
+ * the current directory `./`.
+ */
+function isExplicitRelativePath(sourceName: string): boolean {
+  const [base] = sourceName.split("/", 1);
+  return base === "." || base === "..";
 }
 
 /**

--- a/packages/hardhat-core/test/utils/source-names.ts
+++ b/packages/hardhat-core/test/utils/source-names.ts
@@ -42,6 +42,14 @@ describe("Source names utilities", function () {
       );
     });
 
+    it("Shouldn't fail if it is a dotfile", async function () {
+      validateSourceNameFormat(".asd");
+    });
+
+    it("Shouldn't fail if it is a special dotfile", async function () {
+      validateSourceNameFormat("..asd/");
+    });
+
     it("Should fail if it uses backslash", async function () {
       expectHardhatError(
         () => validateSourceNameFormat("asd\\sd"),


### PR DESCRIPTION
Fixes #995.