### PR TITLE
Add minimum build verification for hardhat-etherscan.

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -931,7 +931,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOB)
         compilationJobs: CompilationJob[];
         compilationJobIndex: number;
         quiet: boolean;
-        emitsArtifacts?: boolean;
+        emitsArtifacts: boolean;
       },
       { run }
     ): Promise<{

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -962,17 +962,17 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOB)
 
       await run(TASK_COMPILE_SOLIDITY_CHECK_ERRORS, { output, quiet });
 
-      const artifactsEmittedPerFile =
-        emitsArtifacts === true
-          ? (
-              await run(TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS, {
-                compilationJob,
-                input,
-                output,
-                solcBuild,
-              })
-            ).artifactsEmittedPerFile
-          : [];
+      let artifactsEmittedPerFile = [];
+      if (emitsArtifacts) {
+        artifactsEmittedPerFile = (
+          await run(TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS, {
+            compilationJob,
+            input,
+            output,
+            solcBuild,
+          })
+        ).artifactsEmittedPerFile;
+      }
 
       return {
         artifactsEmittedPerFile,

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -168,7 +168,7 @@ export class CompilerDownloader {
       try {
         return this._getCompilerBuildByPlatform(version, platform);
       } catch (e) {
-        log("Could'nt download native compiler, using solcjs instead");
+        log("Couldn't download native compiler, using solcjs instead");
       }
     }
 

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -1,6 +1,6 @@
 // This file defines the different config types.
 //
-// For each possible kind of config value, we have two type:
+// For each possible kind of config value, we have two types:
 //
 // One that ends with UserConfig, which represent the config as
 // written in the user's config file.
@@ -180,6 +180,7 @@ export interface ProjectPathsConfig {
 
 // Solidity config
 
+// Note that the user config SolidityUserConfig is more complex than the resolved config SolidityConfig
 export type SolidityUserConfig = string | SolcUserConfig | MultiSolcUserConfig;
 
 export interface SolcUserConfig {

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -45,13 +45,12 @@
     "@types/cbor": "^5.0.1",
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/nock": "^9.3.1",
     "@types/node-fetch": "^2.3.7",
     "@types/semver": "^6.0.2",
     "chai": "^4.2.0",
     "ethers": "^5.0.8",
     "hardhat": "^2.0.0",
-    "nock": "^10.0.6"
+    "nock": "^13.0.5"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
@@ -96,11 +96,7 @@ Reason: ${error.message}`,
   }
 
   if (etherscanResponse.isVerificationFailure()) {
-    throw new NomicLabsHardhatPluginError(
-      pluginName,
-      `The contract verification failed.
-Reason: ${etherscanResponse.message}`
-    );
+    return etherscanResponse;
   }
 
   if (!etherscanResponse.isOk()) {

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -291,11 +291,15 @@ This can occur if the library is only called in the contract constructor.`
     }
 
     console.log(
-      "Verification failed. Falling back to full build verification..."
+      `We tried verifying your contract ${contractInformation.contractName} without including any unrelated one, but it failed.
+Trying again with the full solc input used to compile and deploy it.
+This means that unrelated contracts may be displayed on Etherscan...`
     );
   } else {
     console.log(
-      "Minimum build bytecode did not match. Falling back to full build verification..."
+      `Compiling your contract excluding unrelated contracts did not produce identical bytecode.
+Trying again with the full solc input used to compile and deploy it.
+This means that unrelated contracts may be displayed on Etherscan...`
     );
   }
 

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -15,14 +15,12 @@ import {
   CompilerInput,
   CompilerOutput,
   DependencyGraph,
-  SolcConfig,
 } from "hardhat/types";
 import path from "path";
 import semver from "semver";
 
 import { defaultEtherscanConfig } from "./config";
 import {
-  EtherscanVerifyRequest,
   toCheckStatusRequest,
   toVerifyRequest,
 } from "./etherscan/EtherscanVerifyContractRequest";
@@ -35,6 +33,13 @@ interface VerificationArgs {
   constructorArguments: string[];
   // Filename of constructor arguments module.
   constructorArgs?: string;
+}
+
+interface Build {
+  compilationJob: CompilationJob;
+  input: CompilerInput;
+  output: CompilerOutput;
+  solcBuild: any;
 }
 
 interface MinimumBuildArgs {
@@ -260,9 +265,10 @@ This can occur if the library is only called in the contract constructor.`
 
   const solcFullVersion = await getLongVersion(contractInformation.solcVersion);
 
-  const minimumBuild = await run(TASK_VERIFY_GET_MINIMUM_BUILD, {
+  const minimumBuild: Build = await run(TASK_VERIFY_GET_MINIMUM_BUILD, {
     sourceName: contractInformation.sourceName,
   });
+
   const minimumBuildContractBytecode =
     minimumBuild.output.contracts[contractInformation.sourceName][
       contractInformation.contractName
@@ -409,8 +415,8 @@ task("verify", "Verifies contract on Etherscan")
 
 const getMinimumBuild: ActionType<MinimumBuildArgs> = async function (
   { sourceName },
-  { config, run }
-) {
+  { run }
+): Promise<Build> {
   const dependencyGraph: DependencyGraph = await run(
     TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
     { sourceNames: [sourceName] }
@@ -430,12 +436,7 @@ const getMinimumBuild: ActionType<MinimumBuildArgs> = async function (
     }
   );
 
-  const build: {
-    compilationJob: CompilationJob;
-    input: CompilerInput;
-    output: CompilerOutput;
-    solcBuild: any;
-  } = await run(TASK_COMPILE_SOLIDITY_COMPILE_JOB, {
+  const build: Build = await run(TASK_COMPILE_SOLIDITY_COMPILE_JOB, {
     compilationJob,
     compilationJobs: [compilationJob],
     compilationJobIndex: 0,

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -424,8 +424,8 @@ const getMinimumBuild: ActionType<MinimumBuildArgs> = async function (
 
   const resolvedFiles = dependencyGraph
     .getResolvedFiles()
-    .filter(({ sourceName: thisSourceName }) => {
-      return thisSourceName === sourceName;
+    .filter((resolvedFile) => {
+      return resolvedFile.sourceName === sourceName;
     });
 
   const compilationJob: CompilationJob = await run(

--- a/packages/hardhat-etherscan/src/pluginContext.ts
+++ b/packages/hardhat-etherscan/src/pluginContext.ts
@@ -1,2 +1,3 @@
 export const pluginName = "@nomiclabs/hardhat-etherscan";
+export const TASK_VERIFY = "verify";
 export const TASK_VERIFY_GET_MINIMUM_BUILD = "verify:get-minimum-build";

--- a/packages/hardhat-etherscan/src/pluginContext.ts
+++ b/packages/hardhat-etherscan/src/pluginContext.ts
@@ -1,1 +1,2 @@
 export const pluginName = "@nomiclabs/hardhat-etherscan";
+export const TASK_VERIFY_GET_MINIMUM_BUILD = "verify:get-minimum-build";

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/.gitignore
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/artifacts-dir

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/ReentrancyGuard.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/ReentrancyGuard.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.5.15;
+
+contract ReentrancyGuard {
+    uint256 public guardCounter;
+
+    constructor() internal {
+        guardCounter = 1;
+    }
+
+    modifier nonReentrant() {
+        guardCounter += 1;
+        uint256 localCounter = guardCounter;
+        _;
+        require(localCounter == guardCounter, "re-entered");
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestContract.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestContract.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.5.15;
+
+// import "./libraries/SafeMath.sol";
+import "./TestContract1.sol";
+
+contract TestContract {
+
+    TestContract1 tc1;
+
+    // using SafeMath for uint256;
+
+    uint amount;
+
+    string message = "placeholder";
+
+    constructor(uint _amount) public {
+        amount = _amount + 20;
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestContract1.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestContract1.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.5.15;
+
+contract TestContract1 {
+
+    uint amount;
+
+    string message = "placeholder";
+
+    constructor(uint _amount) public {
+        amount = _amount;
+    }
+}
+
+contract InnerContract {
+
+  function foo() public payable {
+    msg.sender.transfer(msg.value);
+  }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestLibrary.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestLibrary.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.15;
+
+library TestLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+
+    function libID() external returns (string memory) {
+        return "placeholder";
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestParamList.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestParamList.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.5.15;
+
+pragma experimental ABIEncoderV2;
+
+contract TestParamList {
+    struct Point {
+        uint x;
+        uint y;
+    }
+
+    uint public amount;
+    string public aString;
+    Point public point;
+
+    string message = "placeholder";
+
+    constructor(uint _amount, string memory _aString, Point memory _point) public {
+        amount = _amount + 20;
+        aString = _aString;
+        point = _point;
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestReentrancyGuardImported.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestReentrancyGuardImported.sol
@@ -1,0 +1,10 @@
+pragma solidity 0.5.15;
+
+import "./imported/ReentrancyGuard.sol";
+
+contract TestReentrancyGuardImported is ReentrancyGuard {
+
+  function foo() public nonReentrant returns(uint) {
+    return 0;
+  }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestReentrancyGuardLocal.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/TestReentrancyGuardLocal.sol
@@ -1,0 +1,10 @@
+pragma solidity 0.5.15;
+
+import "./ReentrancyGuard.sol";
+
+contract TestReentrancyGuardLocal is ReentrancyGuard {
+
+  function foo() public nonReentrant returns(uint) {
+    return 1;
+  }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/imported/ReentrancyGuard.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/imported/ReentrancyGuard.sol
@@ -1,0 +1,32 @@
+pragma solidity 0.5.15;
+
+/**
+ * @title Helps contracts guard against reentrancy attacks.
+ * @author Remco Bloemen <remco@2π.com>, Eenae <alexey@mixbytes.io>
+ * @dev If you mark a function `nonReentrant`, you should also
+ * mark it `external`.
+ */
+contract ReentrancyGuard {
+    /// @dev counter to allow mutex lock with only one SSTORE operation
+    uint256 private _guardCounter;
+
+    constructor() internal {
+        // The counter starts at one to prevent changing it from zero to a non-zero
+        // value, which is a more expensive operation.
+        _guardCounter = 1;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and make it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _guardCounter += 1;
+        uint256 localCounter = _guardCounter;
+        _;
+        require(localCounter == _guardCounter, "re-entered");
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/libraries/SafeMath.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/contracts/libraries/SafeMath.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.5.15;
+
+
+library SafeMath {
+
+    function mul(uint256 num1, uint256 num2) public pure returns (uint256) {
+        uint256 result = num1 * num2;
+        return result;
+    }
+
+
+    function div(uint256 num1, uint256 num2) public pure returns (uint256) {
+        uint256 result = num1 / num2;
+        return result;
+    }
+
+
+    function sub(uint256 num1, uint256 num2) public pure returns (uint256) {
+        uint256 result = num1 - num2;
+        return result;
+    }
+
+
+    function add(uint256 num1, uint256 num2) public pure returns (uint256) {
+        uint256 result = num1 + num2;
+        return result;
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/hardhat.config.js
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/hardhat.config.js
@@ -1,0 +1,15 @@
+require("@nomiclabs/hardhat-ethers");
+
+require("../../../src/index");
+
+module.exports = {
+  etherscan: {
+    // apiKey: process.env.ETHERSCAN_API_KEY,
+  },
+  solidity: {
+    version: "0.5.15",
+  },
+  paths: {
+    artifacts: "artifacts-dir",
+  },
+};

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/paramList.js
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-only-contracts/paramList.js
@@ -1,0 +1,8 @@
+module.exports = [
+  50,
+  "a constructor argument",
+  {
+    x: 100,
+    y: 120,
+  },
+];

--- a/packages/hardhat-etherscan/test/helpers.ts
+++ b/packages/hardhat-etherscan/test/helpers.ts
@@ -10,7 +10,7 @@ declare module "mocha" {
 
 export function useEnvironment(
   fixtureProjectName: string,
-  networkName = "localhost"
+  networkName = "hardhat"
 ) {
   beforeEach("Loading hardhat environment", function () {
     process.chdir(path.join(__dirname, "fixture-projects", fixtureProjectName));

--- a/packages/hardhat-etherscan/test/integration/PluginTests.ts
+++ b/packages/hardhat-etherscan/test/integration/PluginTests.ts
@@ -1,16 +1,11 @@
 import { assert } from "chai";
-import { readFileSync, writeFileSync } from "fs";
 import {
   TASK_COMPILE,
   TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
 } from "hardhat/builtin-tasks/task-names";
 import type { task as taskT } from "hardhat/config";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
-import type {
-  Artifacts,
-  CompilerInput,
-  HardhatRuntimeEnvironment,
-} from "hardhat/types";
+import type { CompilerInput } from "hardhat/types";
 import path from "path";
 
 import { TASK_VERIFY_GET_MINIMUM_BUILD } from "../../src/pluginContext";

--- a/packages/hardhat-etherscan/test/integration/PluginTests.ts
+++ b/packages/hardhat-etherscan/test/integration/PluginTests.ts
@@ -4,6 +4,7 @@ import { TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import path from "path";
 
+import { TASK_VERIFY_GET_MINIMUM_BUILD } from "../../src/pluginContext";
 import { useEnvironment } from "../helpers";
 
 // These are skipped because they can't currently be run in CI
@@ -164,3 +165,23 @@ async function deployContract(
   await contract.deployTransaction.wait(5);
   return contract.address;
 }
+
+describe("Plugin subtask test", function () {
+  describe("Using a normal Hardhat project", function () {
+    useEnvironment("hardhat-project-only-contracts");
+
+    it("Minimum build subtask should work with simple project", async function () {
+      const sourceName = "contracts/TestContract.sol";
+      const build = await this.env.run(TASK_VERIFY_GET_MINIMUM_BUILD, {
+        sourceName,
+      });
+
+      assert.hasAnyKeys(build.input.sources, [sourceName]);
+      assert.hasAnyKeys(build.output.sources, [sourceName]);
+
+      assert.doesNotHaveAnyKeys(build.output.sources, [
+        "contracts/ReentrancyGuard.sol",
+      ]);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,13 +939,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/nock@^9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-9.3.1.tgz#7d761a43a10aebc7ec6bae29d89afc6cbffa5d30"
-  integrity sha512-eOVHXS5RnWOjTVhu3deCM/ruy9E6JCgeix2g7wpFiekQh3AaEAK1cz43tZDukKmtSmQnwvSySq7ubijCA32I7Q==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node-fetch@^2.3.7", "@types/node-fetch@^2.5.5":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -2418,7 +2411,7 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-chai@^4.1.2, chai@^4.2.0:
+chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -3013,7 +3006,7 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.0, deep-equal@~1.1.1:
+deep-equal@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -5949,12 +5942,17 @@ lodash.partition@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
   integrity sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
 lodash.sum@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lodash.sum/-/lodash.sum-4.0.2.tgz#ad90e397965d803d4f1ff7aa5b2d0197f3b4637b"
   integrity sha1-rZDjl5ZdgD1PH/eqWy0Bl/O0Y3s=
 
-lodash@4.17.20, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.20, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -6467,20 +6465,15 @@ nise@^4.0.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-nock@^10.0.6:
-  version "10.0.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
-  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
+nock@^13.0.5:
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.5.tgz#a618c6f86372cb79fac04ca9a2d1e4baccdb2414"
+  integrity sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==
   dependencies:
-    chai "^4.1.2"
     debug "^4.1.0"
-    deep-equal "^1.0.0"
     json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-    mkdirp "^0.5.0"
-    propagate "^1.0.0"
-    qs "^6.5.1"
-    semver "^5.5.0"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-addon-api@^2.0.0:
   version "2.0.2"
@@ -7141,10 +7134,10 @@ promise-to-callback@^1.0.0:
     is-fn "^1.0.0"
     set-immediate-shim "^1.0.1"
 
-propagate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -7265,7 +7258,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.5.1, qs@^6.7.0:
+qs@^6.7.0:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==


### PR DESCRIPTION
This adds a minimum build subtask that returns compiler input and output
for a single contract. Artifacts are not emitted for this build.

If the minimum build verification fails, the plugin falls back to verifying the contract with a full build.

Fixes #804.