### PR TITLE
Fix a family of slowdown issues with Hardhat providers in ethers.

### DIFF
--- a/packages/hardhat-ethers/src/ethers-provider-wrapper.ts
+++ b/packages/hardhat-ethers/src/ethers-provider-wrapper.ts
@@ -27,4 +27,8 @@ export class EthersProviderWrapper extends ethers.providers.JsonRpcProvider {
 
     return result;
   }
+
+  public toJSON() {
+    return "<WrappedHardhatProvider>";
+  }
 }

--- a/packages/hardhat-ethers/src/signer-with-address.ts
+++ b/packages/hardhat-ethers/src/signer-with-address.ts
@@ -36,4 +36,8 @@ export class SignerWithAddress extends ethers.Signer {
   public connect(provider: ethers.providers.Provider): SignerWithAddress {
     return new SignerWithAddress(this.address, this._signer.connect(provider));
   }
+
+  public toJSON() {
+    return `<SignerWithAddress ${this.address}>`;
+  }
 }

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -387,6 +387,41 @@ describe("Ethers plugin", function () {
             );
           });
 
+          it("should fail to create a contract factory when incorrectly linking a library with an ethers.Contract", async function () {
+            const libraryFactory = await this.env.ethers.getContractFactory(
+              "TestLibrary"
+            );
+            const library = await libraryFactory.deploy();
+
+            try {
+              const contractFactory = await this.env.ethers.getContractFactory(
+                "TestContractLib",
+                { libraries: { TestLibrary: library as any } }
+              );
+            } catch (reason) {
+              assert.instanceOf(
+                reason,
+                NomicLabsHardhatPluginError,
+                "getContractFactory should fail with a hardhat plugin error"
+              );
+              assert.isTrue(
+                reason.message.includes(
+                  "invalid address",
+                  "getContractFactory should report the invalid address as the cause"
+                )
+              );
+              assert.isTrue(
+                reason.message.length <= 400,
+                "getContractFactory should fail with an error message that isn't too large"
+              );
+              return;
+            }
+
+            assert.fail(
+              "getContractFactory should fail to create a contract factory if there is an invalid address"
+            );
+          });
+
           it("Should be able to send txs and make calls", async function () {
             const Greeter = await this.env.ethers.getContractFactory("Greeter");
             const greeter = await Greeter.deploy();

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -410,6 +410,8 @@ describe("Ethers plugin", function () {
                   "getContractFactory should report the invalid address as the cause"
                 )
               );
+              // This assert is here just to make sure we don't end up printing an enormous object
+              // in the error message. This may happen if the argument received is particularly complex.
               assert.isTrue(
                 reason.message.length <= 400,
                 "getContractFactory should fail with an error message that isn't too large"


### PR DESCRIPTION
Closes #1037.

This case was being handled already but I added a test for it since it is quite easy to make this mistake.

Update:
The test wasn't reproducing the issue correctly. There is no way to reproduce it in the plugin test environment that I know of.
#1037 is only one specific way of triggering this slowdown. With this fix, it should be hard to trigger it now.