### PR TITLE
Fix how OOG errors are managed in Hardhat network's stack traces

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
@@ -171,6 +171,19 @@ function encodeStackTraceEntry(
         `internal@${stackTraceEntry.pc}`,
         undefined
       );
+    case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
+      if (stackTraceEntry.sourceReference !== undefined) {
+        return sourceReferenceToSolidityCallsite(
+          stackTraceEntry.sourceReference
+        );
+      }
+
+      return new SolidityCallSite(
+        undefined,
+        UNRECOGNIZED_CONTRACT_NAME,
+        UNKNOWN_FUNCTION_NAME,
+        undefined
+      );
 
     case StackTraceEntryType.OTHER_EXECUTION_ERROR:
       if (stackTraceEntry.sourceReference === undefined) {
@@ -274,6 +287,9 @@ function getMessageFromLastStackTraceEntry(
 
     case StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
       return "Transaction reverted: trying to deploy a contract whose code is too large";
+
+    case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
+      return "Transaction reverted: contract call run out of gas and made the transaction revert";
   }
 }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
@@ -266,7 +266,8 @@ function getMessageFromLastStackTraceEntry(
       return "Transaction reverted without a reason";
 
     case StackTraceEntryType.OTHER_EXECUTION_ERROR:
-      return `Transaction reverted for an unrecognized reason. Please report this to help us improve Hardhat.`;
+      // TODO: What if there was returnData?
+      return `Transaction reverted and Hardhat couldn't infer the reason. Please report this to help us improve Hardhat.`;
 
     case StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
       return "Transaction reverted without a reason and without a valid sourcemap provided by the compiler. Some line numbers may be off. We strongly recommend upgrading solc and always using revert reasons.";

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
@@ -26,6 +26,7 @@ export enum StackTraceEntryType {
   UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
   CONTRACT_TOO_LARGE_ERROR,
   INTERNAL_FUNCTION_CALLSTACK_ENTRY,
+  CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR,
 }
 
 export const FALLBACK_FUNCTION_NAME = "<fallback>";
@@ -160,6 +161,11 @@ export interface InternalFunctionCallStackEntry {
   sourceReference: SourceReference;
 }
 
+export interface ContractCallRunOutOfGasError {
+  type: StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR;
+  sourceReference?: SourceReference;
+}
+
 export type SolidityStackTraceEntry =
   | CallstackEntryStackTraceEntry
   | UnrecognizedCreateCallstackEntryStackTraceEntry
@@ -181,6 +187,7 @@ export type SolidityStackTraceEntry =
   | OtherExecutionErrorStackTraceEntry
   | UnmappedSolc063RevertErrorStackTraceEntry
   | ContractTooLargeErrorStackTraceEntry
-  | InternalFunctionCallStackEntry;
+  | InternalFunctionCallStackEntry
+  | ContractCallRunOutOfGasError;
 
 export type SolidityStackTrace = SolidityStackTraceEntry[];

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
@@ -396,6 +396,14 @@ export class SolidityTracer {
             const subTrace = this.getStackTrace(step);
             stacktrace.push(...subTrace);
 
+            if (this._isContractCallRunOutOfGasError(trace, stepIndex)) {
+              const lastFrame = stacktrace.pop()!;
+              stacktrace.push({
+                type: StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR,
+                sourceReference: lastFrame.sourceReference,
+              });
+            }
+
             consumedAllInstructions = true;
             break;
           }
@@ -576,6 +584,26 @@ export class SolidityTracer {
     }
 
     return this._failsRightAfterCall(trace, callSubtraceStepIndex);
+  }
+
+  private _isContractCallRunOutOfGasError(
+    trace: DecodedEvmMessageTrace,
+    callStepIndex: number
+  ): boolean {
+    if (trace.returnData.length > 0) {
+      return false;
+    }
+
+    if (trace.error?.error !== ERROR.REVERT) {
+      return false;
+    }
+
+    const call = trace.steps[callStepIndex] as MessageTrace;
+    if (call.error?.error !== ERROR.OUT_OF_GAS) {
+      return false;
+    }
+
+    return this._failsRightAfterCall(trace, callStepIndex);
   }
 
   private _isReturnDataSizeError(

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
@@ -568,6 +568,13 @@ export class SolidityTracer {
       return false;
     }
 
+    if (
+      trace.error?.error === ERROR.OUT_OF_GAS &&
+      call.error?.error === ERROR.OUT_OF_GAS
+    ) {
+      return true;
+    }
+
     return this._failsRightAfterCall(trace, callSubtraceStepIndex);
   }
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
@@ -64,10 +64,11 @@ export async function traceTransaction(
 ): Promise<MessageTrace> {
   const tx = new Transaction({
     value: 0,
-    gasLimit: 4000000, // We assume that 4M is enough,
     gasPrice: 1,
     nonce: await getNextNonce(vm),
     ...txData,
+    // If the test didn't define a gasLimit, we assume 4M is enough
+    gasLimit: txData.gasLimit ?? 4000000,
   });
 
   tx.sign(senderPrivateKey);

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_7/out-of-gas/oog-chaining/c.sol
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_7/out-of-gas/oog-chaining/c.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.7.0;
+
+// Note: This test is pretty special and also fragile.
+// It check two kinds of OOGs "chaining":
+//  * When an EVM message (M) OOGs, and the caller message also OOGs while checking if M OOG'd
+//  * When an EVM message OOGs, and the caller reverts because of that
+//
+// The latter case leads to a CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR, but the former just to a CALLSTACK_ENTRY.
+// This test is very sensitive to the compiler being used, its settings, and the gas limit. It is known to work with
+// soljson-v0.7.0+commit.9e61f92b.js, without optimizations, and 4M gas.
+//
+// The reason for it being so sensitive is that we can't test why CALLSTACK_ENTRYs were generated. 
+
+contract O {
+  uint i = 1;
+  
+  function inc() public {
+      i += 1;
+  }
+  
+  function oog() public {
+    for (uint i = 0; i < 10000; i += 1) {
+      this.inc();
+    }
+  }
+}
+
+contract C {
+
+  function test() public {
+    this.oog();
+  }
+  
+  function oog() public {
+    O o = new O();
+    for (uint i = 0; i < 10000; i += 1) {
+      o.oog();
+    }
+  }
+}

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_7/out-of-gas/oog-chaining/test.json
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_7/out-of-gas/oog-chaining/test.json
@@ -1,0 +1,51 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C"
+    },
+    {
+      "to": 0,
+      "function": "test",
+      "gas": 4000000,
+      "stackTrace": [
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "test",
+            "line": 31
+          }
+        },
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "oog",
+            "line": 37
+          }
+        },
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "O",
+            "file": "c.sol",
+            "function": "oog",
+            "line": 23
+          }
+        },
+        {
+          "type": "CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR",
+          "sourceReference": {
+            "contract": "O",
+            "file": "c.sol",
+            "function": "inc",
+            "line": 18
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -84,6 +84,7 @@ interface DeploymentTransaction {
   stackTrace?: StackFrameDescription[]; // No stack trace === the tx MUST be successful
   imports?: string[]; // Imports needed for successful compilation
   consoleLogs?: ConsoleLogs[];
+  gas?: number;
 }
 
 interface CallTransaction {
@@ -98,6 +99,7 @@ interface CallTransaction {
   function?: string; // Default: no data
   params?: Array<string | number>; // Default: no param
   consoleLogs?: ConsoleLogs[];
+  gas?: number;
 }
 
 interface DeployedContract {
@@ -568,6 +570,7 @@ async function runDeploymentTransactionTest(
   const trace = await traceTransaction(vm, {
     value: tx.value,
     data,
+    gasLimit: tx.gas,
   });
 
   return trace as CreateMessageTrace;
@@ -601,6 +604,7 @@ async function runCallTransactionTest(
     to: contract.address,
     value: tx.value,
     data,
+    gasLimit: tx.gas,
   });
 
   return trace as CallMessageTrace;


### PR DESCRIPTION
This PR fixes how out of gas errors are managed by the solidity tracing engine, by introducing two changes:

* Now successive OOGs are chained in a single stack traces. This happens when a contract calls another contract, which OOGs, and makes the caller OOG.
* Detects when a contract call OOGs, making the caller revert. A new stack trace entry type was introduced for this.