### PR TITLE
Ignore the metada hash in the ContractsIdentifier class

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/compiler-to-model.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/compiler-to-model.ts
@@ -5,7 +5,6 @@ import {
   CompilerOutput,
   CompilerOutputBytecode,
 } from "../../../types";
-import { TracingConfig } from "../provider/node-types";
 
 import {
   getLibraryAddressPositions,

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
@@ -37,8 +37,9 @@ class BytecodeTrie {
       currentCodeByte += 1
     ) {
       if (currentCodeByte === bytecode.normalizedCode.length) {
-        // If multiple contracts with the exact same bytecode are added we keep the last of them,
-        // which is probably correct, especially if we are going to support multiple compilations
+        // If multiple contracts with the exact same bytecode are added we keep the last of them.
+        // Note that this includes the metadata hash, so the chances of happening are pretty remote, unless
+        // in super artificial cases that we have in our test suite.
         trieNode.match = bytecode;
         return;
       }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
@@ -229,6 +229,10 @@ export class ContractsIdentifier {
    *
    * The reason we need this function is that the metadata hashes can have common prefixes,
    * and we want to ignore them.
+   *
+   * TODO: There's a small chance of false positive happening here. If we want to
+   *  discard that possibility we need to decode the code into instructions and
+   *  find the first appearance of REVERT INVALID.
    */
   private _getEndOfActualCodesTrie(
     latestMatchedTire: BytecodeTrie,
@@ -258,6 +262,7 @@ export class ContractsIdentifier {
     while (endOfMetadata > endOfActualCode) {
       // The last two bytes of the metadata hash are its big endian length
       // so we check for that.
+      //
       // We just check for the length here. Chances of a false positive are very low.
       const length = code[endOfMetadata] + code[endOfMetadata - 1] * 256;
       if (endOfActualCode + 2 + length === endOfMetadata) {

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
@@ -144,7 +144,19 @@ export class ContractsIdentifier {
       return searchResult;
     }
 
-    // Create traces are followed by metadata that we don't index
+    // Deployment messages have their abi-encoded arguments at the end of the bytecode.
+    //
+    // We don't know how long those arguments are, as we don't know which contract is being
+    // deployed, hence we don't know the signature of its constructor.
+    //
+    // To make things even harder, we can't trust that the user actually passed the right
+    // amount of arguments.
+    //
+    // Luckily, the chances of a complete deployment bytecode being the prefix of another one are
+    // remote. For example, most of the time it ends with its metadata hash, which will differ.
+    //
+    // We take advantage of this last observation, and just return the bytecode that exactly
+    // matched the searchResult (sub)trie that we got.
     if (
       isCreateTrace(trace) &&
       searchResult.match !== undefined &&


### PR DESCRIPTION
This issue is the first step in having stack traces for mainnet contracts. 

I modified the contract identifier class so that it ignores the metadata hash field.

This is really hard to test. We should make the model classes that Hardhat network uses serializable so that we can easily construct test cases using Hardhat, serialize them, and save them.

Please, review this carefully, @fvictorio. If you want, we can jump into a quick call to do it together.