### PR TITLE
Deterministic buildInfo names

### DIFF
--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -287,7 +287,12 @@ export class Artifacts implements IArtifacts {
     solcLongVersion: string,
     input: CompilerInput
   ): string {
-    const json = JSON.stringify({ solcVersion, solcLongVersion, input });
+    const json = JSON.stringify({
+      _format: BUILD_INFO_FORMAT_VERSION,
+      solcVersion,
+      solcLongVersion,
+      input,
+    });
 
     return createNonCryptographicHashBasedIdentifier(
       Buffer.from(json)

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -27,6 +27,7 @@ import {
 import { HardhatError } from "./core/errors";
 import { ERRORS } from "./core/errors-list";
 import { glob, globSync } from "./util/glob";
+import { createNonCryptographicHashBasedIdentifier } from "./util/hash";
 
 const log = debug("hardhat:core:artifacts");
 
@@ -202,12 +203,14 @@ export class Artifacts implements IArtifacts {
     input: CompilerInput,
     output: CompilerOutput
   ): Promise<string> {
-    const { default: uuid } = await import("uuid/v4");
-
     const buildInfoDir = path.join(this._artifactsPath, BUILD_INFO_DIR_NAME);
     await fsExtra.ensureDir(buildInfoDir);
 
-    const buildInfoName = uuid();
+    const buildInfoName = this._getBuildInfoName(
+      solcVersion,
+      solcLongVersion,
+      input
+    );
 
     const buildInfo = this._createBuildInfo(
       buildInfoName,
@@ -277,6 +280,18 @@ export class Artifacts implements IArtifacts {
         await fsExtra.unlink(buildInfoFile);
       }
     }
+  }
+
+  private _getBuildInfoName(
+    solcVersion: string,
+    solcLongVersion: string,
+    input: CompilerInput
+  ): string {
+    const json = JSON.stringify({ solcVersion, solcLongVersion, input });
+
+    return createNonCryptographicHashBasedIdentifier(
+      Buffer.from(json)
+    ).toString("hex");
   }
 
   /**


### PR DESCRIPTION
@wighawag suggested some time ago that build info names should be deterministic, which I think it's a good idea, as it makes collaboration and debugging easier. Right now the names change on every build, so sometimes you lose your references, and makes it harder to communicate with teammates.

I initially thought that using a hash-based identifier would be too slow, as the solc output can be incredibly big. Today I realized that we don't need to include the output in the hash preimage, cause it's deterministically derived from the rest of the fields.

This PR implements just that.

Thanks @wighawag for the idea.