### PR TITLE
Fix eth_call and HarhatProvider's logging initialization

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -21,6 +21,7 @@ import EventEmitter from "events";
 
 import { CompilerInput, CompilerOutput } from "../../../types";
 import { HARDHAT_NETWORK_DEFAULT_GAS_PRICE } from "../../core/config/default-config";
+import { assertHardhatInvariant } from "../../core/errors";
 import { Reporter } from "../../sentry/reporter";
 import { getDifferenceInSeconds } from "../../util/date";
 import { createModelsAndDecodeBytecodes } from "../stack-traces/compiler-to-model";
@@ -71,7 +72,6 @@ import { makeForkClient } from "./utils/makeForkClient";
 import { makeForkCommon } from "./utils/makeForkCommon";
 import { makeStateTrie } from "./utils/makeStateTrie";
 import { putGenesisBlock } from "./utils/putGenesisBlock";
-import { assertHardhatInvariant } from "../../core/errors";
 
 const log = debug("hardhat:core:hardhat-network:node");
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -1351,10 +1351,6 @@ If you are using a wallet or dapp, try resetting your wallet's accounts.`
   /**
    * This function runs a transaction and reverts all the modifications that it
    * makes.
-   *
-   * If throwOnError is true, errors are managed locally and thrown on
-   * failure. If it's false, the tx's RunTxResult is returned, and the vmTracer
-   * inspected/reset.
    */
   private async _runTxAndRevertMutations(
     tx: Transaction,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -71,6 +71,7 @@ import { makeForkClient } from "./utils/makeForkClient";
 import { makeForkCommon } from "./utils/makeForkCommon";
 import { makeStateTrie } from "./utils/makeStateTrie";
 import { putGenesisBlock } from "./utils/putGenesisBlock";
+import { assertHardhatInvariant } from "../../core/errors";
 
 const log = debug("hardhat:core:hardhat-network:node");
 
@@ -1394,8 +1395,15 @@ If you are using a wallet or dapp, try resetting your wallet's accounts.`
         }
       } else {
         // if the context is to run calls with a block
-        // We know that this block number exists.
-        blockContext = (await this.getBlockByNumber(blockNumber))!;
+        // We know that this block number exists, because otherwise
+        // there would be an error in the RPC layer.
+        const block = await this.getBlockByNumber(blockNumber);
+        assertHardhatInvariant(
+          block !== undefined,
+          "Tried to run a tx in the context of a non-existent block"
+        );
+
+        blockContext = block;
 
         if (workaroundEthCallGasLimitIssue) {
           const txGasLimit = new BN(tx.gasLimit);

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -302,6 +302,8 @@ export class HardhatNetworkProvider extends EventEmitter
       }
     );
 
+    this._logger.enable(this._loggingEnabled);
+
     this._forwardNodeEvents(node);
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/types/Block.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/types/Block.ts
@@ -10,12 +10,11 @@ export const Block: BlockConstructor = EthBlock;
 
 // tslint:disable-next-line:no-misused-new
 type BlockConstructor = new (
-  data?: BlockData | null | [Buffer[], Buffer[], Buffer[]],
+  data?: BlockData | null,
   chainOptions?: { common: Common }
 ) => Block;
 
 export interface Block {
-  readonly raw: [Buffer[], Buffer[], Buffer[]];
   readonly header: BlockHeader;
   readonly transactions: Transaction[];
   readonly uncleHeaders: BlockHeader[];

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/types/Block.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/types/Block.ts
@@ -10,11 +10,12 @@ export const Block: BlockConstructor = EthBlock;
 
 // tslint:disable-next-line:no-misused-new
 type BlockConstructor = new (
-  data?: BlockData | null,
+  data?: BlockData | null | [Buffer[], Buffer[], Buffer[]],
   chainOptions?: { common: Common }
 ) => Block;
 
 export interface Block {
+  readonly raw: [Buffer[], Buffer[], Buffer[]];
   readonly header: BlockHeader;
   readonly transactions: Transaction[];
   readonly uncleHeaders: BlockHeader[];

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/contracts-identifier.ts
@@ -27,10 +27,7 @@ class BytecodeTrie {
   public readonly descendants: Bytecode[] = [];
   public match?: Bytecode;
 
-  constructor(
-    public readonly depth: number,
-    public readonly parent?: BytecodeTrie
-  ) {}
+  constructor(public readonly depth: number) {}
 
   public add(bytecode: Bytecode) {
     // tslint:disable-next-line no-this-assignment
@@ -53,7 +50,7 @@ class BytecodeTrie {
 
       let childNode = trieNode.childNodes.get(byte);
       if (childNode === undefined) {
-        childNode = new BytecodeTrie(currentCodeByte, trieNode);
+        childNode = new BytecodeTrie(currentCodeByte);
         trieNode.childNodes.set(byte, childNode);
       }
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -431,6 +431,66 @@ describe("Eth module", function () {
             "0x0000000000000000000000000000000000000000000000000000000000000000"
           );
         });
+
+        it("should run in the context of the blocktag's block", async function () {
+          const contractAddress = await deployContract(
+            this.provider,
+            `0x${EXAMPLE_READ_CONTRACT.bytecode.object}`
+          );
+
+          await this.provider.send("evm_mine", []);
+          await this.provider.send("evm_mine", []);
+
+          const blockResult = await this.provider.send("eth_call", [
+            {
+              to: contractAddress,
+              data: EXAMPLE_READ_CONTRACT.selectors.blockNumber,
+            },
+            "0x1",
+          ]);
+
+          assert.equal(
+            blockResult,
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+          );
+        });
+
+        it("should accept a gas limit higher than the block gas limit being used", async function () {
+          const contractAddress = await deployContract(
+            this.provider,
+            `0x${EXAMPLE_READ_CONTRACT.bytecode.object}`
+          );
+
+          const gas = "0x5f5e100"; // 100M gas
+
+          const blockResult = await this.provider.send("eth_call", [
+            {
+              to: contractAddress,
+              data: EXAMPLE_READ_CONTRACT.selectors.blockNumber,
+              gas,
+            },
+            "0x1",
+          ]);
+
+          assert.equal(
+            blockResult,
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+          );
+
+          const blockResult2 = await this.provider.send("eth_call", [
+            {
+              to: contractAddress,
+              data: EXAMPLE_READ_CONTRACT.selectors.blockNumber,
+              gas,
+            },
+            "pending",
+          ]);
+
+          assert.equal(
+            blockResult2,
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+          );
+        });
       });
 
       describe("eth_chainId", async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import { BN, bufferToHex, toBuffer, zeroAddress } from "ethereumjs-util";
 import { Context } from "mocha";
 
+import { rpcQuantityToNumber } from "../../../../../src/internal/core/providers/provider-utils";
 import { InvalidInputError } from "../../../../../src/internal/hardhat-network/provider/errors";
 import { randomAddress } from "../../../../../src/internal/hardhat-network/provider/fork/random";
 import { COINBASE_ADDRESS } from "../../../../../src/internal/hardhat-network/provider/node";
@@ -438,6 +439,10 @@ describe("Eth module", function () {
             `0x${EXAMPLE_READ_CONTRACT.bytecode.object}`
           );
 
+          const blockNumber = rpcQuantityToNumber(
+            await this.provider.send("eth_blockNumber", [])
+          );
+
           await this.provider.send("evm_mine", []);
           await this.provider.send("evm_mine", []);
 
@@ -446,19 +451,20 @@ describe("Eth module", function () {
               to: contractAddress,
               data: EXAMPLE_READ_CONTRACT.selectors.blockNumber,
             },
-            "0x1",
+            numberToRpcQuantity(blockNumber),
           ]);
 
-          assert.equal(
-            blockResult,
-            "0x0000000000000000000000000000000000000000000000000000000000000001"
-          );
+          assert.equal(dataToNumber(blockResult), blockNumber);
         });
 
         it("should accept a gas limit higher than the block gas limit being used", async function () {
           const contractAddress = await deployContract(
             this.provider,
             `0x${EXAMPLE_READ_CONTRACT.bytecode.object}`
+          );
+
+          const blockNumber = rpcQuantityToNumber(
+            await this.provider.send("eth_blockNumber", [])
           );
 
           const gas = "0x5f5e100"; // 100M gas
@@ -469,13 +475,10 @@ describe("Eth module", function () {
               data: EXAMPLE_READ_CONTRACT.selectors.blockNumber,
               gas,
             },
-            "0x1",
+            numberToRpcQuantity(blockNumber),
           ]);
 
-          assert.equal(
-            blockResult,
-            "0x0000000000000000000000000000000000000000000000000000000000000001"
-          );
+          assert.equal(dataToNumber(blockResult), blockNumber);
 
           const blockResult2 = await this.provider.send("eth_call", [
             {
@@ -486,10 +489,7 @@ describe("Eth module", function () {
             "pending",
           ]);
 
-          assert.equal(
-            blockResult2,
-            "0x0000000000000000000000000000000000000000000000000000000000000002"
-          );
+          assert.equal(dataToNumber(blockResult2), blockNumber + 1);
         });
       });
 


### PR DESCRIPTION
This PR fixes:

1. How HardhatProvider's logging is initialized. `console.log`s weren't going through the logging infra if `loggingEnabled` was true in the `hardhat` network.
2. Fix how `eth_call` handled `blockTag`, actually running the calls in the block's context.
3. Let `eth_call` use gas limit's higher than the block's one. This is implemented with a temporal workaround which has been documented in the code.
