### PR TITLE
Fix Vyper cached compilation

### DIFF
--- a/packages/hardhat-vyper/src/compilation.ts
+++ b/packages/hardhat-vyper/src/compilation.ts
@@ -52,11 +52,11 @@ export async function compile(
     const pathFromSources = path.relative(paths.sources, file);
 
     if (await isAlreadyCompiled(file, paths, vyperVersion, files)) {
-      console.log(pathFromCWD, "is already compiled");
+      console.log("✓", pathFromCWD, "is already compiled");
       continue;
     }
 
-    console.log("Compiling", pathFromCWD);
+    console.log("⌛ Compiling", pathFromCWD);
 
     const processResult = await handleCommonErrors(
       compileWithDocker(file, docker, dockerImage, paths)

--- a/packages/hardhat-vyper/src/compilation.ts
+++ b/packages/hardhat-vyper/src/compilation.ts
@@ -100,7 +100,9 @@ async function isAlreadyCompiled(
   }
 
   const contractName = pathToContractName(sourceFile);
-  const artifactPath = path.join(paths.artifacts, `${contractName}.json`);
+  const contractPath = `/contracts/${sourceFile.split("/contracts")[1]}`;
+  const artifactPath = path.join(paths.artifacts, `${contractPath}/${contractName}.json`);
+
   if (!(await fsExtra.pathExists(artifactPath))) {
     return false;
   }

--- a/packages/hardhat-vyper/src/compilation.ts
+++ b/packages/hardhat-vyper/src/compilation.ts
@@ -100,18 +100,20 @@ async function isAlreadyCompiled(
   }
 
   const contractName = pathToContractName(sourceFile);
-  const contractPath = `/contracts/${sourceFile.split("/contracts")[1]}`;
+  const contractPath = `/contracts${sourceFile.split("/contracts")[1]}`;
   const artifactPath = path.join(paths.artifacts, `${contractPath}/${contractName}.json`);
 
   if (!(await fsExtra.pathExists(artifactPath))) {
     return false;
   }
+  
+  const sourceFilePath = sources.find(s => s.includes(contractPath));
+  if (!sourceFilePath) {
+    return false;
+  }
 
+  const lastSourcesCtime = (await fsExtra.stat(sourceFilePath)).ctimeMs;
   const artifactCtime = (await fsExtra.stat(artifactPath)).ctimeMs;
-
-  const stats = await Promise.all(sources.map((f) => fsExtra.stat(f)));
-
-  const lastSourcesCtime = Math.max(...stats.map((s) => s.ctimeMs));
 
   return lastSourcesCtime < artifactCtime;
 }


### PR DESCRIPTION
Fixes: https://github.com/nomiclabs/hardhat/issues/1107

Fixed the path lookup and the ctime comparison between artifact and source files.