### PR TITLE
Upgrade solidity parser

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@nomiclabs/ethereumjs-vm": "^4.1.1",
     "@sentry/node": "^5.18.1",
-    "@solidity-parser/parser": "^0.7.1",
+    "@solidity-parser/parser": "^0.10.1",
     "@types/bn.js": "^4.11.5",
     "@types/lru-cache": "^5.1.0",
     "abort-controller": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,10 +728,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@solidity-parser/parser@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.7.1.tgz#660210130e4237476cb55e2882064809f80f861e"
-  integrity sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw==
+"@solidity-parser/parser@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.10.1.tgz#d3680d1ebebed21eee67f58a41eb92175204f0c7"
+  integrity sha512-tHDPCRMEBFDxBz5rioQRoKgOQGa/K2digdfR68cd5vO6IufAqoNt1sfjssQDf2KPqHPftICBQOqlcu0w5/Jisg==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Closes #1095.

This PR upgrades `@solidity-parser/parser` to the latest version, that should stop showing the node 14 warning about the circular dependency and should work fine with node versions below 14.