### PR TITLE
Hardhat network configuration should not contain url property

### DIFF
--- a/packages/hardhat-core/src/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-validation.ts
@@ -224,8 +224,8 @@ export function getValidationErrors(config: any): string[] {
   // These can't be validated with io-ts
   if (config !== undefined && typeof config.networks === "object") {
     const hardhatNetwork = config.networks[HARDHAT_NETWORK_NAME];
-    if (hardhatNetwork !== undefined) {
-      if (hardhatNetwork.hasOwnProperty("url")) {
+    if (hardhatNetwork !== undefined && typeof hardhatNetwork === "object") {
+      if ("url" in hardhatNetwork) {
         errors.push(
           `HardhatConfig.networks.${HARDHAT_NETWORK_NAME} can't have an url`
         );

--- a/packages/hardhat-core/src/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-validation.ts
@@ -225,7 +225,7 @@ export function getValidationErrors(config: any): string[] {
   if (config !== undefined && typeof config.networks === "object") {
     const hardhatNetwork = config.networks[HARDHAT_NETWORK_NAME];
     if (hardhatNetwork !== undefined) {
-      if (hardhatNetwork.url !== undefined) {
+      if (hardhatNetwork.hasOwnProperty("url")) {
         errors.push(
           `HardhatConfig.networks.${HARDHAT_NETWORK_NAME} can't have an url`
         );

--- a/packages/hardhat-core/test/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-validation.ts
@@ -689,6 +689,20 @@ describe("Config validation", function () {
             assert.isEmpty(errors);
           });
 
+          it("Should fail if url is set for hardhat network (undefined)", function () {
+            const errors = getValidationErrors({
+              networks: { [HARDHAT_NETWORK_NAME]: { url: undefined } },
+            });
+            assert.isNotEmpty(errors);
+          });
+
+          it("Should fail if url is set for hardhat network", function () {
+            const errors = getValidationErrors({
+              networks: { [HARDHAT_NETWORK_NAME]: { url: "anyurl" } },
+            });
+            assert.isNotEmpty(errors);
+          });
+
           it("Shouldn't fail if no url is set for hardhat network", function () {
             const errors = getValidationErrors({
               networks: { [HARDHAT_NETWORK_NAME]: {} },


### PR DESCRIPTION
Closes #1051.

This PR modified the _configuration validator_ code in order to disallow `url` property of the `hardhat` object. This issue was caused because the modified conditional clause was testing `url` against `undefined`, which is a falsy value, but the property could be present after all. In order not to tackle with validations against this property in a subsequent step of the execution (which indeed is the **purpose** of the _configuration validator_) this conditional clause now uses `.hasOwnProperty` instead of comparing the value with `undefined`, where this property could be present with an undefined value.

Test cases have been added as well for the case of `hardhat` object containing an `url` property with value equal or not equal to `undefined`.

I am happy to bring my efforts to this project by this first contribution and want to thank @alcuadrado for his accompaniment through this task accomplishment.