### PR TITLE
[R4R]add BSC network support for bscscan contract verification

### DIFF
--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -14,6 +14,8 @@ enum NetworkID {
   RINKEBY = 4,
   GOERLI = 5,
   KOVAN = 42,
+  BSC_TESTNET = 97,
+  BSC = 56,
 }
 
 const networkIDtoEndpoint: NetworkMap = {
@@ -22,6 +24,8 @@ const networkIDtoEndpoint: NetworkMap = {
   [NetworkID.RINKEBY]: "https://api-rinkeby.etherscan.io/api",
   [NetworkID.GOERLI]: "https://api-goerli.etherscan.io/api",
   [NetworkID.KOVAN]: "https://api-kovan.etherscan.io/api",
+  [NetworkID.BSC_TESTNET]: "https://api-testnet.bscscan.com/api",
+  [NetworkID.BSC]: "https://api.bscscan.com/api",
 };
 
 export async function getEtherscanEndpoint(


### PR DESCRIPTION
Hi, teams. As BscScan and Etherscan are powered by the same company, it is quite simple to add the support of BSC.
Here is an example that I verified the contract on bscscan: https://testnet.bscscan.com/address/0xa74816243FdD4C16057D41E0100632B1CB90d4a9#code. 

Hope you can merge this PR to enrich the scope of `hardhat`. Appreciate your work to make this so easy to add new network support!