### PR TITLE
Add error message for one case in hardhat-etherscan.

### DIFF
--- a/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
@@ -1,4 +1,5 @@
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
+import type { Response } from "node-fetch";
 
 import { pluginName } from "../constants";
 
@@ -24,27 +25,10 @@ export async function verifyContract(
     method: "post",
     body: parameters,
   };
+
+  let response: Response;
   try {
-    const response = await fetch(url, requestDetails);
-
-    if (!response.ok) {
-      // This could be always interpreted as JSON if there were any such guarantee in the Etherscan API.
-      const responseText = await response.text();
-      throw new NomicLabsHardhatPluginError(
-        pluginName,
-        `The HTTP server response is not ok. Status code: ${response.status} Response text: ${responseText}`
-      );
-    }
-
-    const etherscanResponse = new EtherscanResponse(await response.json());
-    if (!etherscanResponse.isOk()) {
-      throw new NomicLabsHardhatPluginError(
-        pluginName,
-        etherscanResponse.message
-      );
-    }
-
-    return etherscanResponse;
+    response = await fetch(url, requestDetails);
   } catch (error) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
@@ -54,6 +38,40 @@ Reason: ${error.message}`,
       error
     );
   }
+
+  if (!response.ok) {
+    // This could be always interpreted as JSON if there were any such guarantee in the Etherscan API.
+    const responseText = await response.text();
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `Failed to send contract verification request.
+Endpoint URL: ${url}
+The HTTP server response is not ok. Status code: ${response.status} Response text: ${responseText}`
+    );
+  }
+
+  const etherscanResponse = new EtherscanResponse(await response.json());
+
+  if (etherscanResponse.isBytecodeMissingInNetworkError()) {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `Failed to send contract verification request.
+Endpoint URL: ${url}
+Reason: The Etherscan API responded that the address ${req.contractaddress} does not have bytecode.
+This can happen if the contract was recently deployed and this fact hasn't propagated to the backend yet.
+Try waiting for a minute before verifying your contract. If you are invoking this from a script,
+try to wait for five confirmations of your contract deployment transaction before running the verification subtask.`
+    );
+  }
+
+  if (!etherscanResponse.isOk()) {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      etherscanResponse.message
+    );
+  }
+
+  return etherscanResponse;
 }
 
 export async function getVerificationStatus(
@@ -131,6 +149,10 @@ export default class EtherscanResponse {
 
   public isVerificationSuccess() {
     return this.message === "Pass - Verified";
+  }
+
+  public isBytecodeMissingInNetworkError() {
+    return this.message.startsWith("Unable to locate ContractCode at");
   }
 
   public isOk() {

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -178,10 +178,11 @@ See https://etherscan.io/apis`
       pluginName,
       `The constructorArguments parameter should be an array.
 If your constructor has no arguments pass an empty array. E.g:
-await run("${TASK_VERIFY_VERIFY}", {
-  <other args>,
-  constructorArguments: []
-};`
+
+  await run("${TASK_VERIFY_VERIFY}", {
+    <other args>,
+    constructorArguments: []
+  };`
     );
   }
 
@@ -340,7 +341,8 @@ subtask(TASK_VERIFY_GET_CONSTRUCTOR_ARGUMENTS)
           throw new NomicLabsHardhatPluginError(
             pluginName,
             `The module ${constructorArgsModulePath} doesn't export a list. The module should look like this:
-module.exports = [ arg1, arg2, ... ];`
+
+  module.exports = [ arg1, arg2, ... ];`
           );
         }
 
@@ -377,7 +379,8 @@ subtask(TASK_VERIFY_GET_LIBRARIES)
           throw new NomicLabsHardhatPluginError(
             pluginName,
             `The module ${librariesModulePath} doesn't export a dictionary. The module should look like this:
-module.exports = { lib1: "0x...", lib2: "0x...", ... };`
+
+  module.exports = { lib1: "0x...", lib2: "0x...", ... };`
           );
         }
 
@@ -418,7 +421,8 @@ async function attemptVerification(
   console.log(
     `Successfully submitted source code for contract
 ${contractInformation.sourceName}:${contractInformation.contractName} at ${contractAddress}
-for verification on Etherscan. Waiting for verification result...`
+for verification on Etherscan. Waiting for verification result...
+`
   );
 
   const pollRequest = toCheckStatusRequest({
@@ -727,13 +731,15 @@ subtask(TASK_VERIFY_VERIFY_MINIMUM_BUILD)
         console.log(
           `We tried verifying your contract ${contractInformation.contractName} without including any unrelated one, but it failed.
 Trying again with the full solc input used to compile and deploy it.
-This means that unrelated contracts may be displayed on Etherscan...`
+This means that unrelated contracts may be displayed on Etherscan...
+`
         );
       } else {
         console.log(
           `Compiling your contract excluding unrelated contracts did not produce identical bytecode.
 Trying again with the full solc input used to compile and deploy it.
-This means that unrelated contracts may be displayed on Etherscan...`
+This means that unrelated contracts may be displayed on Etherscan...
+`
         );
       }
 

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -291,9 +291,6 @@ Possible causes are:
     return;
   }
 
-  // TODO: Add known edge cases here.
-  // E.g:
-  // - "Unable to locate ContractCode at <address>"
   let errorMessage = `The contract verification failed.
 Reason: ${verificationStatus.message}`;
   if (contractInformation.undetectableLibraries.length > 0) {

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -6,8 +6,13 @@ import { EthereumProvider } from "hardhat/types";
 
 import { pluginName } from "../constants";
 
+export interface EtherscanURLs {
+  apiURL: string;
+  browserURL: string;
+}
+
 type NetworkMap = {
-  [networkID in NetworkID]: string;
+  [networkID in NetworkID]: EtherscanURLs;
 };
 
 // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
@@ -19,18 +24,33 @@ enum NetworkID {
   KOVAN = 42,
 }
 
-const networkIDtoEndpoint: NetworkMap = {
-  [NetworkID.MAINNET]: "https://api.etherscan.io/api",
-  [NetworkID.ROPSTEN]: "https://api-ropsten.etherscan.io/api",
-  [NetworkID.RINKEBY]: "https://api-rinkeby.etherscan.io/api",
-  [NetworkID.GOERLI]: "https://api-goerli.etherscan.io/api",
-  [NetworkID.KOVAN]: "https://api-kovan.etherscan.io/api",
+const networkIDtoEndpoints: NetworkMap = {
+  [NetworkID.MAINNET]: {
+    apiURL: "https://api.etherscan.io/api",
+    browserURL: "https://etherscan.io/",
+  },
+  [NetworkID.ROPSTEN]: {
+    apiURL: "https://api-ropsten.etherscan.io/api",
+    browserURL: "https://ropsten.etherscan.io",
+  },
+  [NetworkID.RINKEBY]: {
+    apiURL: "https://api-rinkeby.etherscan.io/api",
+    browserURL: "https://rinkeby.etherscan.io",
+  },
+  [NetworkID.GOERLI]: {
+    apiURL: "https://api-goerli.etherscan.io/api",
+    browserURL: "https://goerli.etherscan.io",
+  },
+  [NetworkID.KOVAN]: {
+    apiURL: "https://api-kovan.etherscan.io/api",
+    browserURL: "https://kovan.etherscan.io",
+  },
 };
 
-export async function getEtherscanEndpoint(
+export async function getEtherscanEndpoints(
   provider: EthereumProvider,
   networkName: string
-): Promise<string> {
+): Promise<EtherscanURLs> {
   if (networkName === HARDHAT_NETWORK_NAME) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
@@ -40,9 +60,9 @@ export async function getEtherscanEndpoint(
 
   const chainID = parseInt(await provider.send("eth_chainId"), 16) as NetworkID;
 
-  const endpoint = networkIDtoEndpoint[chainID];
+  const endpoints = networkIDtoEndpoints[chainID];
 
-  if (endpoint === undefined) {
+  if (endpoints === undefined) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
       `An etherscan endpoint could not be found for this network. ChainID: ${chainID}. The selected network is ${networkName}.
@@ -53,7 +73,7 @@ Possible causes are:
     );
   }
 
-  return endpoint;
+  return endpoints;
 }
 
 export async function retrieveContractBytecode(

--- a/packages/hardhat-etherscan/test/integration/PluginTests.ts
+++ b/packages/hardhat-etherscan/test/integration/PluginTests.ts
@@ -6,6 +6,8 @@ import {
 import type { task as taskT } from "hardhat/config";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import type { CompilerInput } from "hardhat/types";
+// tslint:disable-next-line: no-implicit-dependencies
+import nock from "nock";
 import path from "path";
 
 import {
@@ -433,6 +435,11 @@ describe("Plugin integration tests", function () {
               "The verification should throw an error when there's an undetectable library address but no libraries parameter was passed."
             );
           })
+          .then(() =>
+            assert.fail(
+              "The verify task should fail when the deployed bytecode is marked with an unexpected compiler version."
+            )
+          )
           .catch((reason) => {
             expect(reason).to.be.an.instanceOf(
               NomicLabsHardhatPluginError,

--- a/packages/hardhat-etherscan/test/integration/PluginTests.ts
+++ b/packages/hardhat-etherscan/test/integration/PluginTests.ts
@@ -6,7 +6,6 @@ import {
 import type { task as taskT } from "hardhat/config";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import type { CompilerInput } from "hardhat/types";
-// tslint:disable-next-line: no-implicit-dependencies
 import nock from "nock";
 import path from "path";
 


### PR DESCRIPTION
The Etherscan backend may not see the deployed bytecode if it was deployed recently. This adds an error message that better describes this issue and recommends waiting for five confirmations at least.

Apart from that, this pull request improves some messages and prints the URL to the verified contract in the console when the verification is successful.