### PR TITLE
Added multiple blocks mining

### DIFF
--- a/docs/hardhat-network/README.md
+++ b/docs/hardhat-network/README.md
@@ -268,6 +268,7 @@ To customise it, take a look at [the configuration section](/config/README.md#ha
 
 - `evm_increaseTime` – same as Ganache.
 - `evm_mine` – same as Ganache
+- `evm_mineMultiple` – this method works like `evm_mine`, but it forces a group of consecutive blocks to be mined. It takes one mandatory and one optional parameter, which are the number of blocks to be mined and the array of timestamps for the mining time of the first k-blocks.
 - `evm_revert` – same as Ganache.
 - `evm_snapshot` – same as Ganache.
 - `evm_setNextBlockTimestamp` - this method works like `evm_increaseTime`, but takes the exact timestamp that you want in the next block, and increases the time accordingly.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/input.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/input.ts
@@ -326,6 +326,12 @@ export function validateParams(params: any[], num: typeof t.number): [number];
 
 export function validateParams(
   params: any[],
+  num: typeof t.number,
+  numarr: typeof t.Array
+): [number, number[]];
+
+export function validateParams(
+  params: any[],
   hash: typeof rpcHash,
   bool: typeof t.boolean
 ): [Buffer, boolean];

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -384,9 +384,9 @@ describe("Evm module", function () {
           );
 
           if (
-            firstMined.timestamp &&
-            secondMined.timestamp &&
-            lastBlock.number
+            firstMined.timestamp !== null &&
+            secondMined.timestamp !== null &&
+            lastBlock.number !== null
           ) {
             assert.equal(
               firstMined.timestamp.substr(2),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -345,7 +345,7 @@ describe("Evm module", function () {
         });
 
         it("should mine multiple blocks faster than unitary version", async function () {
-          const iterations = 10;
+          const iterations = 100;
           let hrTime = process.hrtime();
           for (let it = 0; it < iterations; it++) {
             await this.provider.send("evm_mine");


### PR DESCRIPTION
Closes #1112

By using this approach multiple blocks could be mined with a single call that could specify as parameters:

1. The number of blocks to be mined
2. An array of timestamps to be set for the first mined blocks (optional)

It should be taken into account that naive `_mineEmptyBlock` function is called, where, the inner components of it are not modified.
I would be happy to collaborate by modifying needed code sections as now I am more integrated in the project in order to understand better the source code and its architecture.