### PR TITLE
Fix name resolution for `hardhat/console.sol` when `hardhat` directory exists.

### DIFF
--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -58,7 +58,14 @@ export async function isLocalSourceName(
   projectRoot: string,
   sourceName: string
 ): Promise<boolean> {
-  if (sourceName.includes(NODE_MODULES)) {
+  // Note that we consider "hardhat/console.sol" as a special case here.
+  // This lets someone have a "hardhat" directory within their project without
+  // it impacting their use of `console.log`.
+  // See issue https://github.com/nomiclabs/hardhat/issues/998
+  if (
+    sourceName.includes(NODE_MODULES) ||
+    sourceName === "hardhat/console.sol"
+  ) {
     return false;
   }
 

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/artifacts

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/contracts/Greeter.sol
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/contracts/Greeter.sol
@@ -1,0 +1,23 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.7.0;
+
+import "hardhat/console.sol";
+
+
+contract Greeter {
+  string greeting;
+
+  constructor(string memory _greeting) {
+    console.log("Deploying a Greeter with greeting:", _greeting);
+    greeting = _greeting;
+  }
+
+  function greet() public view returns (string memory) {
+    return greeting;
+  }
+
+  function setGreeting(string memory _greeting) public {
+    console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
+    greeting = _greeting;
+  }
+}

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  solidity: "0.7.3",
+};

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/hardhat/README.md
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/hardhat/README.md
@@ -1,0 +1,4 @@
+# Test description
+
+This fixture project is used in a test for the `source-names` module.
+In particular it was created to write a regression test for this [issue](https://github.com/nomiclabs/hardhat/issues/998).

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -3,6 +3,7 @@ import * as fsExtra from "fs-extra";
 import path from "path";
 import slash from "slash";
 
+import { TASK_COMPILE } from "../../../src/builtin-tasks/task-names";
 import { ERRORS } from "../../../src/internal/core/errors-list";
 import { Parser } from "../../../src/internal/solidity/parse";
 import {
@@ -10,6 +11,7 @@ import {
   Resolver,
 } from "../../../src/internal/solidity/resolver";
 import { LibraryInfo } from "../../../src/types/builtin-tasks";
+import { useEnvironment } from "../../helpers/environment";
 import { expectHardhatErrorAsync } from "../../helpers/errors";
 import {
   getFixtureProjectPath,
@@ -539,6 +541,18 @@ describe("Resolver", function () {
           }
         );
       });
+    });
+  });
+});
+
+describe("Resolver regression tests", function () {
+  describe("Project with a hardhat subdirectory", function () {
+    const projectName = "project-with-hardhat-directory";
+    useFixtureProject(projectName);
+    useEnvironment();
+
+    it("Should compile the Greeter contract that imports console.log from hardhat", async function () {
+      return this.env.run(TASK_COMPILE, { quiet: true });
     });
   });
 });

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -551,6 +551,9 @@ describe("Resolver regression tests", function () {
     useFixtureProject(projectName);
     useEnvironment();
 
+    // This test ensures the resolver lets you compile a project with the packaged console.sol
+    // in a Hardhat project that has a "hardhat" subdirectory.
+    // See issue https://github.com/nomiclabs/hardhat/issues/998
     it("Should compile the Greeter contract that imports console.log from hardhat", async function () {
       return this.env.run(TASK_COMPILE, { quiet: true });
     });

--- a/packages/hardhat-core/test/utils/source-names.ts
+++ b/packages/hardhat-core/test/utils/source-names.ts
@@ -101,6 +101,18 @@ describe("Source names utilities", function () {
         await isLocalSourceName(path.dirname(__dirname), "no/asd")
       );
     });
+
+    // This is a regression test for this issue: https://github.com/nomiclabs/hardhat/issues/998
+    it("Should return false if the source name is 'hardhat/console.sol'", async function () {
+      const projectPath = path.join(
+        path.dirname(__dirname),
+        "fixture-projects",
+        "project-with-hardhat-directory"
+      );
+      assert.isFalse(
+        await isLocalSourceName(projectPath, "hardhat/console.sol")
+      );
+    });
   });
 
   describe("validateSourceNameExistenceAndCasing", function () {


### PR DESCRIPTION
If the directory `hardhat` exists in the project root, then importing
`hardhat/console.sol` fails if it doesn't exist within such a directory.
This adds an exception for this case and ensures the path resolves to
the `console.sol` packaged with Hardhat.

Fixes #998.