### PR TITLE
Add JSON-RPC `eth_signTypedData_v4` method to Hardhat Network.

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
@@ -251,6 +251,14 @@ export class EthModule {
       case "eth_signTypedData":
         return this._signTypedDataAction(...this._signTypedDataParams(params));
 
+      case "eth_signTypedData_v3":
+        throw new MethodNotSupportedError(method);
+
+      case "eth_signTypedData_v4":
+        return this._signTypedDataV4Action(
+          ...this._signTypedDataV4Params(params)
+        );
+
       case "eth_submitHashrate":
         throw new MethodNotSupportedError(method);
 
@@ -884,6 +892,7 @@ export class EthModule {
   // eth_signTypedData
 
   private _signTypedDataParams(params: any[]): [Buffer, any] {
+    // Validation of the TypedData parameter is handled by eth-sig-util
     return validateParams(params, rpcAddress, rpcUnknown);
   }
 
@@ -892,6 +901,36 @@ export class EthModule {
     typedData: any
   ): Promise<string> {
     return this._node.signTypedData(address, typedData);
+  }
+
+  // eth_signTypedData_v4
+
+  private _signTypedDataV4Params(params: any[]): [Buffer, any] {
+    // Validation of the TypedData parameter is handled by eth-sig-util
+    return validateParams(params, rpcAddress, rpcUnknown);
+  }
+
+  private async _signTypedDataV4Action(
+    address: Buffer,
+    typedData: any
+  ): Promise<string> {
+    let typedMessage: any = typedData;
+
+    // According to the MetaMask implementation,
+    // the message parameter may be JSON stringified in versions later than V1
+    // See https://github.com/MetaMask/metamask-extension/blob/0dfdd44ae7728ed02cbf32c564c75b74f37acf77/app/scripts/metamask-controller.js#L1736
+    // In fact, ethers.js JSON stringifies the message at the time of writing.
+    if (typeof typedData === "string") {
+      try {
+        typedMessage = JSON.parse(typedData);
+      } catch (error) {
+        throw new InvalidInputError(
+          `The message parameter is an invalid JSON. Either pass a valid JSON or a plain object conforming to EIP712 TypedData schema.`
+        );
+      }
+    }
+
+    return this._node.signTypedDataV4(address, typedMessage);
   }
 
   // eth_submitHashrate

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
@@ -249,11 +249,15 @@ export class EthModule {
         throw new MethodNotSupportedError(method);
 
       case "eth_signTypedData":
-        return this._signTypedDataAction(...this._signTypedDataParams(params));
+        throw new MethodNotSupportedError(method);
 
       case "eth_signTypedData_v3":
         throw new MethodNotSupportedError(method);
 
+      // TODO: we're currently mimicking the MetaMask implementation here.
+      // The EIP 712 is still a draft. It doesn't actually distinguish different versions
+      // of the eth_signTypedData API.
+      // Also, note that go-ethereum implemented this in a clef JSON-RPC API: account_signTypedData.
       case "eth_signTypedData_v4":
         return this._signTypedDataV4Action(
           ...this._signTypedDataV4Params(params)
@@ -888,20 +892,6 @@ export class EthModule {
   }
 
   // eth_signTransaction
-
-  // eth_signTypedData
-
-  private _signTypedDataParams(params: any[]): [Buffer, any] {
-    // Validation of the TypedData parameter is handled by eth-sig-util
-    return validateParams(params, rpcAddress, rpcUnknown);
-  }
-
-  private async _signTypedDataAction(
-    address: Buffer,
-    typedData: any
-  ): Promise<string> {
-    return this._node.signTypedData(address, typedData);
-  }
 
   // eth_signTypedData_v4
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -620,18 +620,6 @@ export class HardhatNode extends EventEmitter {
     return ecsign(messageHash, privateKey);
   }
 
-  // TODO: we're currently mimicking the MetaMask implementation here.
-  // The EIP 712 is still a draft. It doesn't actually distinguish different versions
-  // of the eth_signTypedData API.
-  // Also, note that go-ethereum implemented this in a clef JSON-RPC API: account_signTypedData.
-  public async signTypedData(address: Buffer, typedData: any): Promise<string> {
-    const privateKey = this._getLocalAccountPrivateKey(address);
-
-    return ethSigUtil.signTypedData(privateKey, {
-      data: typedData,
-    });
-  }
-
   public async signTypedDataV4(
     address: Buffer,
     typedData: any

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import { recoverTypedSignature, recoverTypedSignature_v4 } from "eth-sig-util";
 import Common from "ethereumjs-common";
 import { Transaction } from "ethereumjs-tx";
 import { BN, bufferToHex, toBuffer, zeroAddress } from "ethereumjs-util";
@@ -3390,8 +3391,152 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_signTypedData", async function () {
-        // TODO: Test this. Note that it just forwards to/from eth-sign-util
+      describe("eth_signTypedData", function () {
+        it("should sign a message", async function () {
+          // See https://eips.ethereum.org/EIPS/eip-712#parameters
+          // There's a json schema and an explanation for each field.
+          const typedMessage = {
+            domain: {
+              chainId: 31337,
+              name: "Hardhat Network test suite",
+            },
+            message: {
+              name: "Translation",
+              start: {
+                x: 200,
+                y: 600,
+              },
+              end: {
+                x: 300,
+                y: 350,
+              },
+              cost: 50,
+            },
+            primaryType: "WeightedVector",
+            types: {
+              EIP712Domain: [
+                { name: "name", type: "string" },
+                { name: "chainId", type: "uint256" },
+              ],
+              WeightedVector: [
+                { name: "name", type: "string" },
+                { name: "start", type: "Point" },
+                { name: "end", type: "Point" },
+                { name: "cost", type: "uint256" },
+              ],
+              Point: [
+                { name: "x", type: "uint256" },
+                { name: "y", type: "uint256" },
+              ],
+            },
+          };
+
+          const [address] = DEFAULT_ACCOUNTS_ADDRESSES;
+
+          const signature = await this.provider.request({
+            method: "eth_signTypedData",
+            params: [address, typedMessage],
+          });
+          const signedMessage = {
+            data: typedMessage,
+            sig: signature,
+          };
+
+          const recoveredAddress = recoverTypedSignature(signedMessage as any);
+          assert.equal(address.toLowerCase(), recoveredAddress.toLowerCase());
+        });
+      });
+
+      describe("eth_signTypedData_v3", function () {
+        it("is not supported", async function () {
+          await assertNotSupported(this.provider, "eth_signTypedData_v3");
+        });
+      });
+
+      describe("eth_signTypedData_v4", function () {
+        // See https://eips.ethereum.org/EIPS/eip-712#parameters
+        // There's a json schema and an explanation for each field.
+        const typedMessage = {
+          domain: {
+            chainId: 31337,
+            name: "Hardhat Network test suite",
+          },
+          message: {
+            name: "Translation",
+            start: {
+              x: 200,
+              y: 600,
+            },
+            end: {
+              x: 300,
+              y: 350,
+            },
+            cost: 50,
+          },
+          primaryType: "WeightedVector",
+          types: {
+            EIP712Domain: [
+              { name: "name", type: "string" },
+              { name: "chainId", type: "uint256" },
+            ],
+            WeightedVector: [
+              { name: "name", type: "string" },
+              { name: "start", type: "Point" },
+              { name: "end", type: "Point" },
+              { name: "cost", type: "uint256" },
+            ],
+            Point: [
+              { name: "x", type: "uint256" },
+              { name: "y", type: "uint256" },
+            ],
+          },
+        };
+        const [address] = DEFAULT_ACCOUNTS_ADDRESSES;
+
+        it("should sign a message", async function () {
+          const signature = await this.provider.request({
+            method: "eth_signTypedData_v4",
+            params: [address, typedMessage],
+          });
+          const signedMessage = {
+            data: typedMessage,
+            sig: signature,
+          };
+
+          const recoveredAddress = recoverTypedSignature_v4(
+            signedMessage as any
+          );
+          assert.equal(address.toLowerCase(), recoveredAddress.toLowerCase());
+        });
+
+        it("should sign a message that is JSON stringified", async function () {
+          const signature = await this.provider.request({
+            method: "eth_signTypedData_v4",
+            params: [address, JSON.stringify(typedMessage)],
+          });
+          const signedMessage = {
+            data: typedMessage,
+            sig: signature,
+          };
+
+          const recoveredAddress = recoverTypedSignature_v4(
+            signedMessage as any
+          );
+          assert.equal(address.toLowerCase(), recoveredAddress.toLowerCase());
+        });
+
+        it("should fail with an invalid JSON", async function () {
+          try {
+            const signature = await this.provider.request({
+              method: "eth_signTypedData_v4",
+              params: [address, "{an invalid JSON"],
+            });
+          } catch (error) {
+            assert.include(error.message, "is an invalid JSON");
+            return;
+          }
+          assert.fail("should have failed with an invalid JSON");
+        });
       });
 
       describe("eth_submitHashrate", async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -3392,58 +3392,8 @@ describe("Eth module", function () {
       });
 
       describe("eth_signTypedData", function () {
-        it("should sign a message", async function () {
-          // See https://eips.ethereum.org/EIPS/eip-712#parameters
-          // There's a json schema and an explanation for each field.
-          const typedMessage = {
-            domain: {
-              chainId: 31337,
-              name: "Hardhat Network test suite",
-            },
-            message: {
-              name: "Translation",
-              start: {
-                x: 200,
-                y: 600,
-              },
-              end: {
-                x: 300,
-                y: 350,
-              },
-              cost: 50,
-            },
-            primaryType: "WeightedVector",
-            types: {
-              EIP712Domain: [
-                { name: "name", type: "string" },
-                { name: "chainId", type: "uint256" },
-              ],
-              WeightedVector: [
-                { name: "name", type: "string" },
-                { name: "start", type: "Point" },
-                { name: "end", type: "Point" },
-                { name: "cost", type: "uint256" },
-              ],
-              Point: [
-                { name: "x", type: "uint256" },
-                { name: "y", type: "uint256" },
-              ],
-            },
-          };
-
-          const [address] = DEFAULT_ACCOUNTS_ADDRESSES;
-
-          const signature = await this.provider.request({
-            method: "eth_signTypedData",
-            params: [address, typedMessage],
-          });
-          const signedMessage = {
-            data: typedMessage,
-            sig: signature,
-          };
-
-          const recoveredAddress = recoverTypedSignature(signedMessage as any);
-          assert.equal(address.toLowerCase(), recoveredAddress.toLowerCase());
+        it("is not supported", async function () {
+          await assertNotSupported(this.provider, "eth_signTypedData");
         });
       });
 

--- a/packages/hardhat-ethers/src/signers.ts
+++ b/packages/hardhat-ethers/src/signers.ts
@@ -4,13 +4,6 @@ import { ethers } from "ethers";
 // EIP-712 Typed Data
 // See: https://eips.ethereum.org/EIPS/eip-712
 
-export type SignTypedDataParams = Parameters<
-  ethers.providers.JsonRpcSigner["_signTypedData"]
->;
-
-export type TypedDataDomain = SignTypedDataParams[0];
-export type TypedDataFields = SignTypedDataParams[1];
-
 export class SignerWithAddress extends ethers.Signer {
   public static async create(signer: ethers.providers.JsonRpcSigner) {
     return new SignerWithAddress(await signer.getAddress(), signer);
@@ -49,11 +42,9 @@ export class SignerWithAddress extends ethers.Signer {
   }
 
   public _signTypedData(
-    domain: TypedDataDomain,
-    types: TypedDataFields,
-    value: Record<string, any>
+    ...params: Parameters<ethers.providers.JsonRpcSigner["_signTypedData"]>
   ): Promise<string> {
-    return this._signer._signTypedData(domain, types, value);
+    return this._signer._signTypedData(...params);
   }
 
   public toJSON() {

--- a/packages/hardhat-ethers/src/signers.ts
+++ b/packages/hardhat-ethers/src/signers.ts
@@ -4,18 +4,12 @@ import { ethers } from "ethers";
 // EIP-712 Typed Data
 // See: https://eips.ethereum.org/EIPS/eip-712
 
-interface TypedDataDomain {
-  name?: string;
-  version?: string;
-  chainId?: ethers.BigNumberish;
-  verifyingContract?: string;
-  salt?: ethers.BytesLike;
-}
+export type SignTypedDataParams = Parameters<
+  ethers.providers.JsonRpcSigner["_signTypedData"]
+>;
 
-interface TypedDataField {
-  name: string;
-  type: string;
-}
+export type TypedDataDomain = SignTypedDataParams[0];
+export type TypedDataFields = SignTypedDataParams[1];
 
 export class SignerWithAddress extends ethers.Signer {
   public static async create(signer: ethers.providers.JsonRpcSigner) {
@@ -56,7 +50,7 @@ export class SignerWithAddress extends ethers.Signer {
 
   public _signTypedData(
     domain: TypedDataDomain,
-    types: Record<string, TypedDataField[]>,
+    types: TypedDataFields,
     value: Record<string, any>
   ): Promise<string> {
     return this._signer._signTypedData(domain, types, value);

--- a/packages/hardhat-ethers/src/signers.ts
+++ b/packages/hardhat-ethers/src/signers.ts
@@ -1,9 +1,5 @@
 import { ethers } from "ethers";
 
-// This is taken from @ethersproject/abstract-signer package.
-// EIP-712 Typed Data
-// See: https://eips.ethereum.org/EIPS/eip-712
-
 export class SignerWithAddress extends ethers.Signer {
   public static async create(signer: ethers.providers.JsonRpcSigner) {
     return new SignerWithAddress(await signer.getAddress(), signer);

--- a/packages/hardhat-ethers/src/signers.ts
+++ b/packages/hardhat-ethers/src/signers.ts
@@ -1,13 +1,30 @@
 import { ethers } from "ethers";
 
+// This is taken from @ethersproject/abstract-signer package.
+// EIP-712 Typed Data
+// See: https://eips.ethereum.org/EIPS/eip-712
+
+interface TypedDataDomain {
+  name?: string;
+  version?: string;
+  chainId?: ethers.BigNumberish;
+  verifyingContract?: string;
+  salt?: ethers.BytesLike;
+}
+
+interface TypedDataField {
+  name: string;
+  type: string;
+}
+
 export class SignerWithAddress extends ethers.Signer {
-  public static async create(signer: ethers.Signer) {
+  public static async create(signer: ethers.providers.JsonRpcSigner) {
     return new SignerWithAddress(await signer.getAddress(), signer);
   }
 
   private constructor(
     public readonly address: string,
-    private readonly _signer: ethers.Signer
+    private readonly _signer: ethers.providers.JsonRpcSigner
   ) {
     super();
     (this as any).provider = _signer.provider;
@@ -35,6 +52,14 @@ export class SignerWithAddress extends ethers.Signer {
 
   public connect(provider: ethers.providers.Provider): SignerWithAddress {
     return new SignerWithAddress(this.address, this._signer.connect(provider));
+  }
+
+  public _signTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, TypedDataField[]>,
+    value: Record<string, any>
+  ): Promise<string> {
+    return this._signer._signTypedData(domain, types, value);
   }
 
   public toJSON() {

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -774,10 +774,6 @@ describe("Ethers plugin", function () {
       assert.lengthOf(code, 2);
     });
 
-    /*
-      This test is commented out because it uses
-      Signer._signTypedData, an experimental ethers.js method
-
     it("_signTypedData integration test", async function () {
       // See https://eips.ethereum.org/EIPS/eip-712#parameters
       // There's a json schema and an explanation for each field.
@@ -817,15 +813,18 @@ describe("Ethers plugin", function () {
           ],
         },
       };
-      const signer = await this.env.ethers.provider.getSigner(0);
+      const signer = this.env.ethers.provider.getSigner(0);
 
-      const signature = await signer._signTypedData(typedMessage.domain, typedMessage.types, typedMessage.message);
+      const signature = await signer._signTypedData(
+        typedMessage.domain,
+        typedMessage.types,
+        typedMessage.message
+      );
 
       const byteToHex = 2;
       const hexPrefix = 2;
-      const signatureSizeInBytes = 65
+      const signatureSizeInBytes = 65;
       assert.lengthOf(signature, signatureSizeInBytes * byteToHex + hexPrefix);
     });
-    */
   });
 });

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -813,7 +813,7 @@ describe("Ethers plugin", function () {
           ],
         },
       };
-      const signer = this.env.ethers.provider.getSigner(0);
+      const [signer] = await this.env.ethers.getSigners();
 
       const signature = await signer._signTypedData(
         typedMessage.domain,

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -773,5 +773,56 @@ describe("Ethers plugin", function () {
       code = await this.env.ethers.provider.getCode(receipt.contractAddress);
       assert.lengthOf(code, 2);
     });
+
+    /*
+    it("_signTypedData integration test", async function () {
+      // See https://eips.ethereum.org/EIPS/eip-712#parameters
+      // There's a json schema and an explanation for each field.
+      const typedMessage = {
+        domain: {
+          chainId: 31337,
+          name: "Hardhat Network test suite",
+        },
+        message: {
+          name: "Translation",
+          start: {
+            x: 200,
+            y: 600,
+          },
+          end: {
+            x: 300,
+            y: 350,
+          },
+          cost: 50,
+        },
+        primaryType: "WeightedVector",
+        types: {
+          // ethers.js derives the EIP712Domain type from the domain object itself
+          // EIP712Domain: [
+          //   { name: "name", type: "string" },
+          //   { name: "chainId", type: "uint256" },
+          // ],
+          WeightedVector: [
+            { name: "name", type: "string" },
+            { name: "start", type: "Point" },
+            { name: "end", type: "Point" },
+            { name: "cost", type: "uint256" },
+          ],
+          Point: [
+            { name: "x", type: "uint256" },
+            { name: "y", type: "uint256" },
+          ],
+        },
+      };
+      const signer = await this.env.ethers.provider.getSigner(0);
+
+      const signature = await signer._signTypedData(typedMessage.domain, typedMessage.types, typedMessage.message);
+
+      const byteToHex = 2;
+      const hexPrefix = 2;
+      const signatureSizeInBytes = 65
+      assert.lengthOf(signature, signatureSizeInBytes * byteToHex + hexPrefix);
+    });
+    */
   });
 });

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -775,6 +775,9 @@ describe("Ethers plugin", function () {
     });
 
     /*
+      This test is commented out because it uses
+      Signer._signTypedData, an experimental ethers.js method
+
     it("_signTypedData integration test", async function () {
       // See https://eips.ethereum.org/EIPS/eip-712#parameters
       // There's a json schema and an explanation for each field.


### PR DESCRIPTION
This pull request:
- Adds JSON-RPC method `eth_signTypedData_v4` and implements it with `signTypedData_v4` of `eth-sig-util`.
  - Its implementation mimics MetaMask's. It attempts to parse the typed message parameter as a JSON if it is a string.
- Modifies the JSON-RPC method `eth_signTypedData` to mark it as not supported.
- Adds JSON-RPC method `eth_signTypedData_v3` and marks it as not supported.
- Adds method `_signTypedData` for `SignerWithAddress` in `hardhat-ethers`.
- Adds test in `hardhat-ethers` for `SignerWithAddress._signTypedData`.

Context:  [EIP712](https://eips.ethereum.org/EIPS/eip-712) early implementation.