### PR TITLE
doc: add warning block about async Waffle matchers

### DIFF
--- a/docs/guides/waffle-testing.md
+++ b/docs/guides/waffle-testing.md
@@ -80,7 +80,7 @@ We are requiring `Chai` which is an assertions library. These asserting function
 This is why we're using the `hardhat-waffle` plugin, which makes it easier to assert values from Ethereum. Check out [this section](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html) in Waffle's documentation for the entire list of Ethereum-specific matchers.
 
 ::: warning
-Some Waffle matchers return a Promise rather than executing immediately. If you're making a call or sending a transaction, make sure to check Waffe's documentation, and `await` these Promises. Otherwise your tests may pass without running all checks.
+Some Waffle matchers return a Promise rather than executing immediately. If you're making a call or sending a transaction, make sure to check Waffle's documentation, and `await` these Promises. Otherwise your tests may pass without running all checks.
 :::
 
 ```js

--- a/docs/guides/waffle-testing.md
+++ b/docs/guides/waffle-testing.md
@@ -79,6 +79,10 @@ We are requiring `Chai` which is an assertions library. These asserting function
 
 This is why we're using the `hardhat-waffle` plugin, which makes it easier to assert values from Ethereum. Check out [this section](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html) in Waffle's documentation for the entire list of Ethereum-specific matchers.
 
+::: warning
+Some Waffle matchers return a Promise rather than executing immediately. If you're making a call or sending a transaction, make sure to check Waffe's documentation, and `await` these Promises. Otherwise your tests may pass without running all checks.
+:::
+
 ```js
 describe("Greeter", function () {
   it("Should return the new greeting once it's changed", async function () {


### PR DESCRIPTION
Adds a warning block describing asynchronous Waffle matchers to the testing documentation. 

I chose to place this immediately after the existing link to Waffle docs and description of matcher use. I chose to make it a warning as improper usage results in false negatives when testing.

To consider: recommend using the eslint `no-floating-promises` plugin?

Discussion coming from here:
https://twitter.com/_prestwich/status/1355623851246247936