### PR TITLE
Update debugging-with-hardhat-network.md

### DIFF
--- a/docs/tutorial/debugging-with-hardhat-network.md
+++ b/docs/tutorial/debugging-with-hardhat-network.md
@@ -23,7 +23,7 @@ function transfer(address to, uint256 amount) external {
     console.log("Sender balance is %s tokens", balances[msg.sender]);
     console.log("Trying to send %s tokens to %s", amount, to);
 
-    require(balances[msg.sender] >= amount, "Not enough tokens");
+    require(balances[msg.sender] <= amount, "Not enough tokens");
 
     balances[msg.sender] -= amount;
     balances[to] += amount;


### PR DESCRIPTION
For the require (Token.sol) first argument to evaluates to `false` is necessary to change the position of _expect_ and _await_ interchangeably:

Token.js (test)

    it("Should fail if sender doesn’t have enough tokens", async function () {
      const initialOwnerBalance = await hardhatToken.balanceOf(owner.address);

      // Try to send 1 token from addr1 (0 tokens) to owner (1000 tokens).
      // `require` will evaluate false and revert the transaction.
      **expect**(
        **await** hardhatToken.connect(addr1).transfer(owner.address, 1)
      ).to.be.revertedWith("Not enough tokens");