### PR TITLE
Fix tests that depend on a 0 nonce

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -11,6 +11,10 @@ export const DEFAULT_NETWORK_ID = 234;
 export const DEFAULT_BLOCK_GAS_LIMIT = 6000000;
 export const DEFAULT_USE_JSON_RPC = false;
 export const DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE = false;
+
+// Assumptions:
+// - First account has sent some transactions on mainnet
+// - Second and third accounts have a 0 nonce
 export const DEFAULT_ACCOUNTS = [
   {
     privateKey:
@@ -20,6 +24,11 @@ export const DEFAULT_ACCOUNTS = [
   {
     privateKey:
       "0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd10a",
+    balance: new BN(10).pow(new BN(18)),
+  },
+  {
+    privateKey:
+      "0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd10b",
     balance: new BN(10).pow(new BN(18)),
   },
 ];

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -657,6 +657,7 @@ describe("Eth module", function () {
           await assertNodeBalances(this.provider, [
             DEFAULT_ACCOUNTS_BALANCES[0].subn(1 + 21000),
             DEFAULT_ACCOUNTS_BALANCES[1].addn(1),
+            ...DEFAULT_ACCOUNTS_BALANCES.slice(2),
           ]);
 
           await this.provider.send("eth_sendTransaction", [
@@ -672,6 +673,7 @@ describe("Eth module", function () {
           await assertNodeBalances(this.provider, [
             DEFAULT_ACCOUNTS_BALANCES[0].subn(1 + 21000 + 2 + 21000 * 2),
             DEFAULT_ACCOUNTS_BALANCES[1].addn(1 + 2),
+            ...DEFAULT_ACCOUNTS_BALANCES.slice(2),
           ]);
         });
 
@@ -2153,7 +2155,7 @@ describe("Eth module", function () {
           const firstBlock = await getFirstBlock();
           const txParams1: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer("0xaa"),
             nonce: new BN(0),
             value: new BN(123),
@@ -2187,7 +2189,7 @@ describe("Eth module", function () {
 
           const txParams2: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer([]),
             nonce: new BN(1),
             value: new BN(123),
@@ -2251,7 +2253,7 @@ describe("Eth module", function () {
           const firstBlock = await getFirstBlock();
           const txParams1: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer("0xaa"),
             nonce: new BN(0),
             value: new BN(123),
@@ -2285,7 +2287,7 @@ describe("Eth module", function () {
 
           const txParams2: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer([]),
             nonce: new BN(1),
             value: new BN(123),
@@ -2338,7 +2340,7 @@ describe("Eth module", function () {
           const firstBlock = await getFirstBlock();
           const txParams1: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer("0xaa"),
             nonce: new BN(0),
             value: new BN(123),
@@ -2372,7 +2374,7 @@ describe("Eth module", function () {
 
           const txParams2: TransactionParams = {
             to: toBuffer(zeroAddress()),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer([]),
             nonce: new BN(1),
             value: new BN(123),
@@ -2409,7 +2411,7 @@ describe("Eth module", function () {
           const firstBlock = await getFirstBlock();
           const txParams: TransactionParams = {
             to: toBuffer([]),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer("0x60006000fd"),
             nonce: new BN(0),
             value: new BN(123),
@@ -2420,7 +2422,7 @@ describe("Eth module", function () {
           const txHash = await getSignedTxHash(
             this.hardhatNetworkProvider,
             txParams,
-            0
+            1
           );
 
           // Revert. This is a deployment transaction that immediately reverts without a reason
@@ -2596,30 +2598,6 @@ describe("Eth module", function () {
         it("Should return the updated count after a transaction is made", async function () {
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
-            ]),
-            0
-          );
-
-          await this.provider.send("eth_sendTransaction", [
-            {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
-              value: numberToRpcQuantity(1),
-              gas: numberToRpcQuantity(21000),
-              gasPrice: numberToRpcQuantity(1),
-            },
-          ]);
-
-          assertQuantity(
-            await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
-            ]),
-            1
-          );
-
-          assertQuantity(
-            await this.provider.send("eth_getTransactionCount", [
               DEFAULT_ACCOUNTS_ADDRESSES[1],
             ]),
             0
@@ -2637,31 +2615,22 @@ describe("Eth module", function () {
 
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
-            ]),
-            1
-          );
-
-          assertQuantity(
-            await this.provider.send("eth_getTransactionCount", [
               DEFAULT_ACCOUNTS_ADDRESSES[1],
             ]),
             1
           );
-        });
 
-        it("Should not be affected by calls", async function () {
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
+              DEFAULT_ACCOUNTS_ADDRESSES[2],
             ]),
             0
           );
 
-          await this.provider.send("eth_call", [
+          await this.provider.send("eth_sendTransaction", [
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[2],
+              to: DEFAULT_ACCOUNTS_ADDRESSES[2],
               value: numberToRpcQuantity(1),
               gas: numberToRpcQuantity(21000),
               gasPrice: numberToRpcQuantity(1),
@@ -2670,7 +2639,40 @@ describe("Eth module", function () {
 
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
+              DEFAULT_ACCOUNTS_ADDRESSES[1],
+            ]),
+            1
+          );
+
+          assertQuantity(
+            await this.provider.send("eth_getTransactionCount", [
+              DEFAULT_ACCOUNTS_ADDRESSES[2],
+            ]),
+            1
+          );
+        });
+
+        it("Should not be affected by calls", async function () {
+          assertQuantity(
+            await this.provider.send("eth_getTransactionCount", [
+              DEFAULT_ACCOUNTS_ADDRESSES[1],
+            ]),
+            0
+          );
+
+          await this.provider.send("eth_call", [
+            {
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              to: DEFAULT_ACCOUNTS_ADDRESSES[2],
+              value: numberToRpcQuantity(1),
+              gas: numberToRpcQuantity(21000),
+              gasPrice: numberToRpcQuantity(1),
+            },
+          ]);
+
+          assertQuantity(
+            await this.provider.send("eth_getTransactionCount", [
+              DEFAULT_ACCOUNTS_ADDRESSES[1],
             ]),
             0
           );
@@ -2680,8 +2682,8 @@ describe("Eth module", function () {
           const firstBlock = await getFirstBlock();
           await this.provider.send("eth_sendTransaction", [
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              to: DEFAULT_ACCOUNTS_ADDRESSES[2],
               value: numberToRpcQuantity(1),
             },
           ]);
@@ -2689,7 +2691,7 @@ describe("Eth module", function () {
           if (!isFork) {
             assertQuantity(
               await this.provider.send("eth_getTransactionCount", [
-                DEFAULT_ACCOUNTS_ADDRESSES[0],
+                DEFAULT_ACCOUNTS_ADDRESSES[1],
                 "earliest",
               ]),
               0
@@ -2698,7 +2700,7 @@ describe("Eth module", function () {
 
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
+              DEFAULT_ACCOUNTS_ADDRESSES[1],
               numberToRpcQuantity(firstBlock),
             ]),
             0
@@ -2706,7 +2708,7 @@ describe("Eth module", function () {
 
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [
-              DEFAULT_ACCOUNTS_ADDRESSES[0],
+              DEFAULT_ACCOUNTS_ADDRESSES[1],
               "latest",
             ]),
             1
@@ -2799,7 +2801,7 @@ describe("Eth module", function () {
         it("should return the receipt for txs that were executed and failed", async function () {
           const txParams: TransactionParams = {
             to: toBuffer([]),
-            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[0]),
+            from: toBuffer(DEFAULT_ACCOUNTS_ADDRESSES[1]),
             data: toBuffer("0x60006000fd"),
             nonce: new BN(0),
             value: new BN(123),
@@ -2810,7 +2812,7 @@ describe("Eth module", function () {
           const txHash = await getSignedTxHash(
             this.hardhatNetworkProvider,
             txParams,
-            0
+            1
           );
 
           // Revert. This is a deployment transaction that immediately reverts without a reason
@@ -3192,7 +3194,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               to: zeroAddress(),
               gas: numberToRpcQuantity(1),
             },
@@ -3203,7 +3205,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               to: zeroAddress(),
               gas: numberToRpcQuantity(21000),
               gasPrice: numberToRpcQuantity(DEFAULT_ACCOUNTS_BALANCES[0]),
@@ -3215,7 +3217,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               to: zeroAddress(),
               gas: numberToRpcQuantity(DEFAULT_BLOCK_GAS_LIMIT + 1),
             },
@@ -3229,7 +3231,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               data: "0xAA",
             },
             "Transaction reverted without a reason"
@@ -3244,7 +3246,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               data:
                 "0x6000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000",
               gas: numberToRpcQuantity(53500),
@@ -3256,8 +3258,8 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-              to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
               nonce: numberToRpcQuantity(1),
             },
             "Invalid nonce. Expected 2 but got 1"
@@ -3268,7 +3270,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               data: "0x60006000fd",
             },
             "Transaction reverted without a reason"
@@ -3278,7 +3280,7 @@ describe("Eth module", function () {
           await assertTransactionFailure(
             this.provider,
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
               data:
                 "0x6080604052348015600f57600080fd5b506040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260018152602001807f410000000000000000000000000000000000000000000000000000000000000081525060200191505060405180910390fdfe",
             },
@@ -3288,8 +3290,8 @@ describe("Eth module", function () {
 
         it("Should fail if a successful tx is sent more than once", async function () {
           const txParams = {
-            from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-            to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+            from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+            to: DEFAULT_ACCOUNTS_ADDRESSES[1],
             nonce: numberToRpcQuantity(0),
           };
 
@@ -3306,8 +3308,8 @@ describe("Eth module", function () {
 
         it("should accept a failed transaction if it eventually becomes valid", async function () {
           const txParams = {
-            from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-            to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+            from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+            to: DEFAULT_ACCOUNTS_ADDRESSES[1],
             nonce: numberToRpcQuantity(1),
           };
 
@@ -3316,8 +3318,8 @@ describe("Eth module", function () {
 
           await this.provider.send("eth_sendTransaction", [
             {
-              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
-              to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
               nonce: numberToRpcQuantity(0),
             },
           ]);

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -444,7 +444,7 @@ describe("Evm module", function () {
           });
 
           it("Deletes previous transactions", async function () {
-            const [from] = await this.provider.send("eth_accounts");
+            const [, from] = await this.provider.send("eth_accounts");
 
             const snapshotId: string = await this.provider.send(
               "evm_snapshot",
@@ -475,7 +475,7 @@ describe("Evm module", function () {
           });
 
           it("Allows resending the same tx after a revert", async function () {
-            const [from] = await this.provider.send("eth_accounts");
+            const [, from] = await this.provider.send("eth_accounts");
 
             const snapshotId: string = await this.provider.send(
               "evm_snapshot",
@@ -614,13 +614,15 @@ describe("Evm module", function () {
               toFake: ["Date"],
             });
 
+            const firstBlock = await mineEmptyBlock();
             await this.provider.send("evm_increaseTime", [100]);
             const snapshotBlock = await mineEmptyBlock();
+
             const snapshotId = await this.provider.send("evm_snapshot");
 
             assert.equal(
               quantityToNumber(snapshotBlock.timestamp),
-              getCurrentTimestamp() + 100
+              quantityToNumber(firstBlock.timestamp) + 100
             );
 
             sinonClock.tick(20 * 1000);
@@ -639,7 +641,7 @@ describe("Evm module", function () {
           it("Restores the previous state", async function () {
             // This is a very coarse test, as we know that the entire state is
             // managed by the vm, and is restored as a whole
-            const [from] = await this.provider.send("eth_accounts");
+            const [, from] = await this.provider.send("eth_accounts");
 
             const balanceBeforeTx = await this.provider.send("eth_getBalance", [
               from,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -101,13 +101,22 @@ describe("Evm module", function () {
         });
 
         it("should return the total offset as a decimal string, not a QUANTITY", async function () {
+          // get the current offset
+          const initialOffset = parseInt(
+            await this.provider.send("evm_increaseTime", [0]),
+            10
+          );
+
           let totalOffset = await this.provider.send("evm_increaseTime", [123]);
           assert.isString(totalOffset);
-          assert.strictEqual(parseInt(totalOffset, 10), 123);
+          assert.strictEqual(parseInt(totalOffset, 10), initialOffset + 123);
 
           totalOffset = await this.provider.send("evm_increaseTime", [3456789]);
           assert.isString(totalOffset);
-          assert.strictEqual(parseInt(totalOffset, 10), 123 + 3456789);
+          assert.strictEqual(
+            parseInt(totalOffset, 10),
+            initialOffset + 123 + 3456789
+          );
         });
 
         it("should expect an actual number as its first param, not a hex string", async function () {


### PR DESCRIPTION
Several tests were assuming the first account had a 0 nonce, and therefore they broke after #979.

This PR mostly moves those tests to use the second account, that right now has a nonce of 0. This is very brittle, of course, but it should work for now.

There is only one non-trivial change, I will comment it inline.