### PR TITLE
Increase timeout for hardhat-truffle5 tests

### DIFF
--- a/packages/hardhat-truffle5/.mocharc.json
+++ b/packages/hardhat-truffle5/.mocharc.json
@@ -2,5 +2,5 @@
   "require": "ts-node/register/files",
   "file": "../common/run-with-ganache",
   "ignore": ["test/fixture-projects/**/*"],
-  "timeout": 10000
+  "timeout": 90000
 }


### PR DESCRIPTION
I don't have a Windows machine to verify, but it appears that this CI test is failing due to timeout for a long-running test.