### PR TITLE
Fix Hardhat Network bugs

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -22,7 +22,6 @@ import {
 
 export class JsonRpcClient {
   private _cache: Map<string, any> = new Map();
-  private _scopedForkCacheFolderCreated?: boolean;
 
   constructor(
     private _httpProvider: HttpProvider,
@@ -429,11 +428,7 @@ export class JsonRpcClient {
   ) {
     const requestPath = this._getDiskCachePathForKey(forkCachePath, cacheKey);
 
-    if (this._scopedForkCacheFolderCreated !== true) {
-      this._scopedForkCacheFolderCreated = true;
-      await fsExtra.ensureDir(path.dirname(requestPath));
-    }
-
+    await fsExtra.ensureDir(path.dirname(requestPath));
     await fsExtra.writeJSON(requestPath, rawResult, {
       encoding: "utf8",
     });


### PR DESCRIPTION
This PR fixes two errors in Hardhat Network:

1. A race condition in the fork's jsonrpc client's cache.
2. Previously, internal errors were treated as unrecognized reverts. This lead to many unrelated errors that happened when forking (e.g. HTTP errors) being treated as reverts. They are now rethrown.