### PR TITLE
fix: storage slot param validation

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -37,14 +37,14 @@ export class JsonRpcClient {
 
   public async getStorageAt(
     address: Buffer,
-    position: Buffer,
+    position: BN,
     blockNumber: BN
   ): Promise<Buffer> {
     return this._perform(
       "eth_getStorageAt",
       [
         bufferToHex(address),
-        bufferToHex(position),
+        numberToRpcQuantity(position),
         numberToRpcQuantity(blockNumber),
       ],
       rpcData,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkStateManager.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkStateManager.ts
@@ -192,7 +192,7 @@ export class ForkStateManager implements PStateManager {
 
     const remoteValue = await this._jsonRpcClient.getStorageAt(
       address,
-      key,
+      new BN(key),
       this._contextBlockNumber
     );
 

--- a/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
@@ -50,7 +50,7 @@ describe("JsonRpcClient", () => {
       function getStorageAt(blockNumber: number) {
         return clientWithFakeProvider.getStorageAt(
           DAI_ADDRESS,
-          DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+          new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
           new BN(blockNumber)
         );
       }
@@ -187,7 +187,7 @@ describe("JsonRpcClient", () => {
 
         const value = await clientWithFakeProvider.getStorageAt(
           DAI_ADDRESS,
-          DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+          new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
           new BN(120)
         );
         assert.equal((fakeProvider.request as sinon.SinonStub).callCount, 2);
@@ -218,7 +218,7 @@ describe("JsonRpcClient", () => {
         await assert.isRejected(
           clientWithFakeProvider.getStorageAt(
             DAI_ADDRESS,
-            DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+            new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
             new BN(120)
           ),
           "header not found"
@@ -246,7 +246,7 @@ describe("JsonRpcClient", () => {
         await assert.isRejected(
           clientWithFakeProvider.getStorageAt(
             DAI_ADDRESS,
-            DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+            new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
             new BN(120)
           ),
           "different error"
@@ -274,7 +274,7 @@ describe("JsonRpcClient", () => {
         await assert.isRejected(
           clientWithFakeProvider.getStorageAt(
             DAI_ADDRESS,
-            DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+            new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
             new BN(120)
           ),
           "header not found"
@@ -383,7 +383,7 @@ describe("JsonRpcClient", () => {
           it("can fetch value from storage of an existing contract", async () => {
             const totalSupply = await client.getStorageAt(
               DAI_ADDRESS,
-              DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+              new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
               forkNumber
             );
             const totalSupplyBN = new BN(totalSupply);
@@ -393,7 +393,7 @@ describe("JsonRpcClient", () => {
           it("can fetch empty value from storage of an existing contract", async () => {
             const value = await client.getStorageAt(
               DAI_ADDRESS,
-              toBuffer("0xbaddcafe"),
+              new BN("0xbaddcafe"),
               forkNumber
             );
             const valueBN = new BN(value);
@@ -403,7 +403,7 @@ describe("JsonRpcClient", () => {
           it("can fetch empty value from storage of a non-existent contract", async () => {
             const value = await client.getStorageAt(
               EMPTY_ACCOUNT_ADDRESS,
-              toBuffer([1]),
+              new BN(1),
               forkNumber
             );
             const valueBN = new BN(value);

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkStateManager.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkStateManager.ts
@@ -238,7 +238,7 @@ describe("ForkStateManager", () => {
     it("can get contract storage value", async () => {
       const remoteValue = await client.getStorageAt(
         DAI_ADDRESS,
-        DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+        new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
         forkBlockNumber
       );
 
@@ -255,7 +255,7 @@ describe("ForkStateManager", () => {
     it("can get contract storage value", async () => {
       const remoteValue = await client.getStorageAt(
         DAI_ADDRESS,
-        DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+        new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
         forkBlockNumber
       );
       const fsmValue = await fsm.getOriginalContractStorage(
@@ -617,7 +617,7 @@ describe("ForkStateManager", () => {
         const oldBlock = forkBlockNumber.subn(10);
         const valueAtOldBlock = await client.getStorageAt(
           DAI_ADDRESS,
-          DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+          new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
           oldBlock
         );
 
@@ -690,7 +690,7 @@ describe("ForkStateManager", () => {
       it("restores the fork block context in which methods operate", async () => {
         const valueAtForkBlock = await client.getStorageAt(
           DAI_ADDRESS,
-          DAI_TOTAL_SUPPLY_STORAGE_POSITION,
+          new BN(DAI_TOTAL_SUPPLY_STORAGE_POSITION),
           forkBlockNumber
         );
         const getStorageAt = sinon.spy(client, "getStorageAt");


### PR DESCRIPTION
I discovered this while toying around with a fork of a fork (mainnet => hardhat fork => hardhat fork) to optimize our test run performance.

~~The storage slot parameter is currently incorrectly validated via the `rpcQuantity` type.~~

