### PR TITLE
Enable caching in Ropsten forks

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
@@ -25,6 +25,11 @@ export function getLargestPossibleReorg(networkId: number): number | undefined {
   if (networkId === 4) {
     return 5;
   }
+
+  // Ropsten
+  if (networkId === 3) {
+    return 100;
+  }
 }
 
 export const FALLBACK_MAX_REORG = 30;


### PR DESCRIPTION
This PR enables caching in Hardhat Network's forking when using Ropsten.

The reason this wasn't enabled before was that there's no clear info about what was the max reorg on Ropsten. We assume now that 100 is a reasonable bound. This may not be the case, but we'd revisit it if it were to happen.

@fvictorio do you think we can add this to tomorrow's release?