### PR TITLE
fix: pad mixHash to 32 bytes

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
@@ -113,7 +113,7 @@ export function getRpcBlock(
     // We pad this to 8 bytes because of a limitation in The Graph
     // See: https://github.com/nomiclabs/hardhat/issues/491
     nonce: pending ? null : bufferToRpcData(block.header.nonce, 16),
-    mixHash: pending ? null : bufferToRpcData(block.header.mixHash, 32),
+    mixHash: pending ? null : bufferToRpcData(block.header.mixHash, 64),
     sha3Uncles: bufferToRpcData(block.header.uncleHash),
     logsBloom: pending ? null : bufferToRpcData(block.header.bloom),
     transactionsRoot: bufferToRpcData(block.header.transactionsTrie),


### PR DESCRIPTION
mixHash is a [32 byte value](https://sourcegraph.com/github.com/ethereum/go-ethereum/-/blob/core/types/block.go#L83:21). The call to`bufferToRpcData` only pads the `mixHash` to 32 hexadecimal characters, which is 16 bytes. 

Currently this is breaking my usage of a forked Hardhat network with running a graph-node - https://github.com/graphprotocol/graph-node/issues/2212.