### PR TITLE
Add BSC support to buidler-etherscan

### DIFF
--- a/packages/buidler-etherscan/src/network/prober.ts
+++ b/packages/buidler-etherscan/src/network/prober.ts
@@ -14,6 +14,7 @@ enum NetworkID {
   RINKEBY = 4,
   GOERLI = 5,
   KOVAN = 42,
+  BSC = 56,
 }
 
 const networkIDtoEndpoint: NetworkMap = {
@@ -22,6 +23,7 @@ const networkIDtoEndpoint: NetworkMap = {
   [NetworkID.RINKEBY]: "https://api-rinkeby.etherscan.io/api",
   [NetworkID.GOERLI]: "https://api-goerli.etherscan.io/api",
   [NetworkID.KOVAN]: "https://api-kovan.etherscan.io/api",
+  [NetworkID.BSC]: "https://api.bscscan.com/api",
 };
 
 export class NetworkProberError extends BuidlerPluginError {


### PR DESCRIPTION
Some of our repositories have not yet migrated to hardhat (I know shame on us) but we would still like to verify contracts on BSC.

This PR adds the relevant API url for bscscan.