### PR TITLE
use new smock default branch in docs

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -271,7 +271,7 @@ const plugins = [
     name: "@eth-optimisim/smock",
     author: "Optimism",
     authorUrl: "https://github.com/ethereum-optimism",
-    url: "https://github.com/ethereum-optimism/smock/tree/master",
+    url: "https://github.com/ethereum-optimism/smock/tree/nu-nu",
     description:
       "smock is a utility package that can generate mock Solidity contracts written entirely in JavaScript.",
     tags: ["Testing", "Mocking", "Buidler plugin"],


### PR DESCRIPTION
The smock repo's new default branch is "nu-nu". NPM downloads the version on this branch by default. The usage changed substantially so it took some effort to find correct example code.