### PR TITLE
Update docs on supported flavor of signTypedData

### DIFF
--- a/docs/hardhat-network/README.md
+++ b/docs/hardhat-network/README.md
@@ -344,7 +344,7 @@ To customise it, take a look at [the configuration section](/config/README.md#ha
 - `eth_pendingTransactions`
 - `eth_sendRawTransaction`
 - `eth_sendTransaction`
-- `eth_signTypedData`
+- `eth_signTypedData_v4`
 - `eth_sign`
 - `eth_subscribe`
 - `eth_syncing`

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "Nomic Labs LLC",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://hardhat.org",

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,11 +585,6 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-"@nomiclabs/hardhat-ethers@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.1.tgz#f86a6fa210dbe6270adffccc75e93ed60a856904"
-  integrity sha512-uTFHDhhvJ+UjfvvMeQxD3ZALuzuI3FXzTYT1Z5N3ebyZL5z4Ogwt55GB0R9tdKY0p5HhDhBjU/gsCjUEwIVoaw==
-
 "@nomiclabs/truffle-contract@^4.2.23":
   version "4.2.23"
   resolved "https://registry.yarnpkg.com/@nomiclabs/truffle-contract/-/truffle-contract-4.2.23.tgz#3431d09d2400413d3a14650494abc0a6233c16d4"


### PR DESCRIPTION
Vanilla `eth_signTypedData` was marked as unsupported in https://github.com/nomiclabs/hardhat/pull/1189, in favor of the v4 version. This PR updates the docs to reflect that.