### PR TITLE
The MM GitHub issue has moved - fixed link

### DIFF
--- a/docs/metamask-issue.md
+++ b/docs/metamask-issue.md
@@ -11,7 +11,7 @@ If you are using MetaMask with Hardhat Network, you might get an error like this
 Incompatible EIP155-based V 2710 and chain id 31337. See the second parameter of the Transaction constructor to set the chain id.
 ```
 
-This is because MetaMask mistakenly assumes all networks in `http://localhost:8545` to have a chain id of `1337`, but Hardhat uses a different number by default. **Please voice your support for MetaMask to fix this on [the MetaMask issue about it](https://github.com/MetaMask/metamask-extension/issues/9827).**
+This is because MetaMask mistakenly assumes all networks in `http://localhost:8545` to have a chain id of `1337`, but Hardhat uses a different number by default. **Please voice your support for MetaMask to fix this on [the MetaMask issue about it](https://github.com/MetaMask/metamask-extension/issues/10290).**
 
 In the meantime, to resolve this you can set the `chainId` of Hardhat Network to `1337` in your Hardhat config:
 


### PR DESCRIPTION
The original GitHub issue linked has been closed, and a new one has been opened to support HH out of the box.

Old value: https://github.com/MetaMask/metamask-extension/issues/9827
New value: https://github.com/MetaMask/metamask-extension/issues/10290.

This PR updates the link to point to the new issue.