### PR TITLE
Smaller downloader fix

### DIFF
--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -39,7 +39,7 @@ export interface CompilersList {
 
 const log = debug("hardhat:core:solidity:downloader");
 
-const COMPILER_FILES_DIR_URL_SOLC = "https://solc-bin.ethereum.org/";
+const COMPILER_FILES_DIR_URL_SOLC = "https://binaries.soliditylang.org/";
 
 async function downloadFile(
   url: string,

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -92,6 +92,7 @@ export class CompilerDownloader {
 
     if (expectedKeccak256 !== compilerKeccak256) {
       await fsExtra.unlink(downloadedFilePath);
+      await fsExtra.unlink(this.getCompilersListPath(compilerBuild.platform));
 
       throw new HardhatError(ERRORS.SOLC.INVALID_DOWNLOAD, {
         remoteVersion: compilerBuild.version,
@@ -158,7 +159,7 @@ export class CompilerDownloader {
       await this.downloadCompilersList(platform);
     }
 
-    return fsExtra.readJson(this._getCompilersListPath(platform));
+    return fsExtra.readJson(this.getCompilersListPath(platform));
   }
 
   public async getCompilerBuild(version: string): Promise<CompilerBuild> {
@@ -179,7 +180,7 @@ export class CompilerDownloader {
     try {
       await this._download(
         getCompilerListURL(platform),
-        this._getCompilersListPath(platform)
+        this.getCompilersListPath(platform)
       );
     } catch (error) {
       throw new HardhatError(
@@ -217,7 +218,11 @@ export class CompilerDownloader {
   }
 
   public async compilersListExists(platform: CompilerPlatform) {
-    return fsExtra.pathExists(this._getCompilersListPath(platform));
+    return fsExtra.pathExists(this.getCompilersListPath(platform));
+  }
+
+  public getCompilersListPath(platform: CompilerPlatform) {
+    return path.join(this._compilersDir, platform, "list.json");
   }
 
   private _getDownloadedFilePath(compilerBuild: CompilerBuild): string {
@@ -238,7 +243,7 @@ export class CompilerDownloader {
 
     // We may need to re-download the compilers list.
     if (compilerBuildPath === undefined && compilersListExisted) {
-      await fsExtra.unlink(this._getCompilersListPath(platform));
+      await fsExtra.unlink(this.getCompilersListPath(platform));
 
       list = await this.getCompilersList(platform);
       compilerBuildPath = list.releases[version];
@@ -269,10 +274,6 @@ export class CompilerDownloader {
 
     compilerBuild.platform = platform;
     return compilerBuild;
-  }
-
-  private _getCompilersListPath(platform: CompilerPlatform) {
-    return path.join(this._compilersDir, platform, "list.json");
   }
 
   private async _fileExists(filePath: string) {

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -84,7 +84,7 @@ describe("Compiler downloader", function () {
     it("should call the download function with the right params", async function () {
       const compilersDir = this.tmpDir;
       const downloadPath = path.join(compilersDir, "downloadedCompiler");
-      const expectedUrl = `https://solc-bin.ethereum.org/wasm/${localCompilerBuild.path}`;
+      const expectedUrl = `https://binaries.soliditylang.org/wasm/${localCompilerBuild.path}`;
 
       let urlUsed: string | undefined;
       let pathUsed: string | undefined;
@@ -122,7 +122,7 @@ describe("Compiler downloader", function () {
   describe("Compilers list download", function () {
     it("Should call download with the right params", async function () {
       const compilersDir = this.tmpDir;
-      const expectedUrl = `https://solc-bin.ethereum.org/wasm/list.json`;
+      const expectedUrl = `https://binaries.soliditylang.org/wasm/list.json`;
 
       let urlUsed: string | undefined;
       let pathUsed: string | undefined;


### PR DESCRIPTION
This PR fixes #1332 and replaces #1329.

The difference with this PR is that it doesn't add support for nightly versions, but just fixes #1332 and updates the compilers repository url.

The implementation in #1329 lead to some really slow startup times (>10sec) in some cases, so we should redesign it. I created it so that we can push this fix in the next release, and later add support for the nightlies.