### PR TITLE
Changing ethereum/vyper to vyperlang/vyper in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,15 @@ All tests are written using [mocha](https://mochajs.org) and [chai](https://www.
 ### Per-package
 You can run a package's tests by executing `yarn test` inside its folder.
 
-_Note_: for package [hardhat-vyper](./packages/hardhat-vyper) case, a running instance of Docker Desktop is required, with `ethereum/vyper` image pulled. To install it, run:
+_Note_: for package [hardhat-vyper](./packages/hardhat-vyper) case, a running instance of Docker Desktop is required, with `vyperlang/vyper` image pulled. To install it, run:
 ```
-docker pull ethereum/vyper:0.1.0b10
+docker pull vyperlang/vyper:0.1.0b10
 ```
 
 ### Entire project
 You can run all the tests at once by running `yarn test` from the root folder.
 
-For the case of package [hardhat-vyper](./packages/hardhat-vyper), an `ethereum/vyper` docker instance installed is required (see previous section for details). _Exception_ of this requirement is if running on a Windows local machine, in this case we skip it by default since Win 10 Pro version would be also required.
+For the case of package [hardhat-vyper](./packages/hardhat-vyper), an `vyperlang/vyper` docker instance installed is required (see previous section for details). _Exception_ of this requirement is if running on a Windows local machine, in this case we skip it by default since Win 10 Pro version would be also required.
 
 ## Code formatting
 

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -12,7 +12,7 @@ This plugin adds support for Vyper to Hardhat. Once installed, Vyper contracts c
 This plugin generates the same artifact format as the built-in Solidity compiler, so that it can be used in conjunction with
 all other plugins.
 
-The Vyper compiler is run using the [official Docker images](https://hub.docker.com/r/ethereum/vyper).
+The Vyper compiler is run using the [official Docker images](https://hub.docker.com/r/vyperlang/vyper).
 
 ## Installation
 
@@ -51,14 +51,14 @@ This plugin does not extend the Hardhat Runtime Environment.
 ## Configuration
 
 This plugin adds an optional `vyper` entry to Hardhat's config, which lets you specify the Vyper version to use. If no
-version is given, the [latest one on Docker Hub](https://hub.docker.com/r/ethereum/vyper/tags) will be used.
+version is given, the [latest one on Docker Hub](https://hub.docker.com/r/vyperlang/vyper/tags) will be used.
 
 This is an example of how to set it:
 
 ```js
 module.exports = {
   vyper: {
-    version: "0.1.0b9"
+    version: "0.1.0b10"
   }
 };
 ```


### PR DESCRIPTION
Is it like still relevant to have 0.1.0b10 in docs? 
imho, 0.2.x looks a lil bit better