### PR TITLE
Support HexEqual with hardhat waffle

### DIFF
--- a/packages/hardhat-waffle/src/waffle-chai.ts
+++ b/packages/hardhat-waffle/src/waffle-chai.ts
@@ -43,7 +43,8 @@ export function waffleChai(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
   const {
     supportRevertedWith,
   } = require(`${waffleChaiPath}/matchers/revertedWith`);
-
+  const { supportHexEqual } = require(`${waffleChaiPath}/matchers/hexEqual`);
+  
   supportBigNumber(chai.Assertion, utils);
   supportReverted(chai.Assertion);
   supportRevertedWith(chai.Assertion);
@@ -51,6 +52,7 @@ export function waffleChai(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
   supportProperAddress(chai.Assertion);
   supportProperPrivateKey(chai.Assertion);
   supportProperHex(chai.Assertion);
+  supportHexEqual(chai.Assertion);
   supportChangeBalance(chai.Assertion);
   supportChangeBalances(chai.Assertion);
   supportChangeEtherBalance(chai.Assertion);

--- a/packages/hardhat-waffle/test/fixture-projects/hardhat-project/test/tests.js
+++ b/packages/hardhat-waffle/test/fixture-projects/hardhat-project/test/tests.js
@@ -144,5 +144,10 @@ describe("Internal test suite of hardhat-waffle's test project", function () {
       expect("0x70").to.be.properHex(2);
       expect("foobar").not.to.be.properHex(2);
     });
+    
+    it("should support the hexEqual matcher", async function() {
+      expect('0x00012AB').to.hexEqual('0x12ab');
+      expect('0xdeadbeaf').not.to.hexEqual('0x12ab');
+    });
   });
 });


### PR DESCRIPTION
The current package does not support the hexEqual Chai matcher.

https://ethereum-waffle.readthedocs.io/en/latest/matchers.html#hex-equal