### PR TITLE
Allow forking cache on network without known reorg

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
@@ -81,7 +81,7 @@ Please use block number ${lastSafeBlock} or wait for the block to get ${
   const cacheToDiskEnabled =
     forkConfig.blockNumber !== undefined &&
     forkCachePath !== undefined &&
-    actualMaxReorg !== undefined;
+    maxReorg !== undefined;
 
   const forkClient = new JsonRpcClient(
     provider,


### PR DESCRIPTION
I was trying to fork the xdai network and noticed that nothing was being cached (which is a massive problem because their archive RPC drops connections all the time); however, I found that it wouldn't be cached because it is not in the list of known reorgs since `actualMaxReorg` was being checked instead of `maxReorg` which has the fallback.

This change allows any forked network to be cached.