### PR TITLE
Add ArgumentsExtenders

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -26,6 +26,7 @@
     "node": ">=8.2.0"
   },
   "scripts": {
+    "prepack": "yarn build",
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\" && yarn lint-src --fix && yarn lint-tests --fix",
     "lint": "yarn lint-src && yarn lint-tests",
     "lint-tests": "NODE_OPTIONS='--require ts-node/register/transpile-only' tslint --config tslint.json --project ./tsconfig.json",

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -16,7 +16,6 @@ import { getEnvHardhatArguments } from "../core/params/env-variables";
 import { HARDHAT_PARAM_DEFINITIONS } from "../core/params/hardhat-params";
 import { isCwdInsideProject } from "../core/project-structure";
 import { Environment } from "../core/runtime-environment";
-import { loadTsNode, willRunWithTypescript } from "../core/typescript-support";
 import { Reporter } from "../sentry/reporter";
 import { isRunningOnCiServer } from "../util/ci-detection";
 import {
@@ -74,6 +73,16 @@ async function main() {
       process.argv.slice(2)
     );
 
+    const ctx = HardhatContext.createHardhatContext();
+
+    let taskName = parsedTaskName ?? TASK_HELP;
+
+    const showSolidityConfigWarnings = taskName === TASK_COMPILE;
+
+    const config = loadConfigAndTasks(hardhatArguments, {
+      showSolidityConfigWarnings,
+    });
+
     if (hardhatArguments.verbose) {
       Reporter.setVerbose(true);
       debug.enable("hardhat*");
@@ -103,19 +112,6 @@ async function main() {
     if (!isHardhatInstalledLocallyOrLinked()) {
       throw new HardhatError(ERRORS.GENERAL.NON_LOCAL_INSTALLATION);
     }
-
-    if (willRunWithTypescript(hardhatArguments.config)) {
-      loadTsNode();
-    }
-
-    let taskName = parsedTaskName ?? TASK_HELP;
-
-    const showSolidityConfigWarnings = taskName === TASK_COMPILE;
-
-    const ctx = HardhatContext.createHardhatContext();
-    const config = loadConfigAndTasks(hardhatArguments, {
-      showSolidityConfigWarnings,
-    });
 
     let telemetryConsent: boolean | undefined = hasConsentedTelemetry();
 

--- a/packages/hardhat-core/src/internal/context.ts
+++ b/packages/hardhat-core/src/internal/context.ts
@@ -1,4 +1,5 @@
 import {
+  ArgumentsExtender,
   ConfigExtender,
   ExperimentalHardhatNetworkMessageTraceHook,
   HardhatRuntimeEnvironment,
@@ -47,6 +48,7 @@ export class HardhatContext {
   public readonly tasksDSL = new TasksDSL();
   public readonly extendersManager = new ExtenderManager();
   public environment?: HardhatRuntimeEnvironment;
+  public readonly argumentsExtenders: ArgumentsExtender[] = [];
   public readonly configExtenders: ConfigExtender[] = [];
 
   // NOTE: This is experimental and will be removed. Please contact our team if

--- a/packages/hardhat-core/src/internal/core/config/config-env.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-env.ts
@@ -1,5 +1,6 @@
 import {
   ActionType,
+  ArgumentsExtender,
   ConfigExtender,
   ConfigurableTaskDefinition,
   EnvironmentExtender,
@@ -116,6 +117,17 @@ export function subtask<ArgsT extends TaskArguments>(
 export const internalTask = subtask;
 
 export const types = argumentTypes;
+
+/**
+ * Register an arguments extender what will be run before the
+ * config is initialized.
+ *
+ * @param extender A function that receives the HardhatArguments.
+ */
+export function extendArguments(extender: ArgumentsExtender) {
+  const ctx = HardhatContext.getHardhatContext();
+  ctx.argumentsExtenders.push(extender);
+}
 
 /**
  * Register an environment extender what will be run after the

--- a/packages/hardhat-core/src/types/runtime.ts
+++ b/packages/hardhat-core/src/types/runtime.ts
@@ -199,6 +199,12 @@ export interface Network {
 }
 
 /**
+ * A function that receives HardhatArguments and
+ * modify its properties.
+ */
+export type ArgumentsExtender = (args: Partial<HardhatArguments>) => void;
+
+/**
  * A function that receives a HardhatRuntimeEnvironment and
  * modify its properties or add new ones.
  */


### PR DESCRIPTION
Adds an `extender` function for modifying the Hardhat arguments before executing anything. This allows for performing verification on the `hre.network` before connecting to / forking a network. 

The `HardhatConfig.networks.hardhat` configuration is not dynamically loaded and is unable to change after the `hardhat` script executes. This means that you can only have 1 configuration set for being able to fork a network. If you want to fork multiple networks, you will need to manually update the `hardhat` network config before executing the script. 

Instead, it would be nice to specify that I want to fork in the command I want to run and the network I want to fork:
`FORKING_ENABLED=true yarn hh test --network {mainnet|polygon}`

```typescript
extendArguments((args: Partial<HardhatArguments>) => {
  if (process.env.FORKING_ENABLED === 'true' && args.network !== HARDHAT_NETWORK_NAME) {
    process.env.FORKING_NETWORK = args.network
    args.network = 'hardhat'
  }
})

extendConfig((config: HardhadConfig) => {
  if (process.env.FORKING_NETWORK != null) {
    const networkConfig = config.networks[process.env.FORKING_NETWORK]
    if (!('url' in networkConfig)) {
      throw new Error(`Invalid forking network config`)
    }

    const { url: forkingUrl, ...rest } = networkConfig
    const forkingConfig: HardhatNetworkUserConfig = {
      ...rest,
      chainId: 31337,
      accounts,
      forking: {
        url: forkingUrl,
        blockNumber: networkConfig.forkBlockNumber,
        enabled: true
      },
      saveDeployments: true,
      live: false
    }

    merge(
      config.networks.hardhat,
      forkingConfig
    )
  }
})
```

```typescript
{
  ...,
  networks: {
    kovan: networkConfig({
      url: process.env.ALCHEMY_KOVAN_KEY!,
      chainId: 42,
      live: true
    }),
    mainnet: networkConfig({
      url: process.env.ALCHEMY_MAINNET_KEY!,
      chainId: 1,
      live: true,
      forkBlockNumber: 12480795,
    }),
    polygon: networkConfig({
      url: `https://rpc-mainnet.maticvigil.com`,
      chainId: 137,
      live: true,
      // forkBlockNumber: 14891625,
    }),
    localhost: networkConfig({
      url: 'http://127.0.0.1:8545',
      timeout: 100000,
    }),
  }
}
```