### PR TITLE
Wait for tx to be mined in sample project

### DIFF
--- a/packages/hardhat-core/sample-project/test/sample-test.js
+++ b/packages/hardhat-core/sample-project/test/sample-test.js
@@ -4,11 +4,13 @@ describe("Greeter", function() {
   it("Should return the new greeting once it's changed", async function() {
     const Greeter = await ethers.getContractFactory("Greeter");
     const greeter = await Greeter.deploy("Hello, world!");
-    
     await greeter.deployed();
+
     expect(await greeter.greet()).to.equal("Hello, world!");
 
-    await greeter.setGreeting("Hola, mundo!");
+    const setGreetingTx = await greeter.setGreeting("Hola, mundo!");
+    await setGreetingTx.wait();
+
     expect(await greeter.greet()).to.equal("Hola, mundo!");
   });
 });

--- a/packages/hardhat-core/sample-project/test/sample-test.js
+++ b/packages/hardhat-core/sample-project/test/sample-test.js
@@ -9,6 +9,8 @@ describe("Greeter", function() {
     expect(await greeter.greet()).to.equal("Hello, world!");
 
     const setGreetingTx = await greeter.setGreeting("Hola, mundo!");
+    
+    // wait until the transaction is mined
     await setGreetingTx.wait();
 
     expect(await greeter.greet()).to.equal("Hola, mundo!");


### PR DESCRIPTION
The reason to do this is that otherwise the test doesn't work out-of-the-box when run against a testnet.