### PR TITLE
Add FIFO mode to the transaction pool

### DIFF
--- a/.changeset/fair-monkeys-cheat.md
+++ b/.changeset/fair-monkeys-cheat.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Add a FIFO mode to Hardhat Network's mempool (Thanks @ngotchac!)

--- a/packages/hardhat-core/src/internal/constants.ts
+++ b/packages/hardhat-core/src/internal/constants.ts
@@ -20,6 +20,8 @@ export const HARDHAT_NETWORK_SUPPORTED_HARDFORKS = [
   "london",
 ];
 
+export const HARDHAT_MEMPOOL_SUPPORTED_ORDERS = <const>["fifo", "priority"];
+
 export const ARTIFACT_FORMAT_VERSION = "hh-sol-artifact-1";
 export const DEBUG_FILE_FORMAT_VERSION = "hh-sol-dbg-1";
 export const BUILD_INFO_FORMAT_VERSION = "hh-sol-build-info-1";

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -10,6 +10,8 @@ import {
   HardhatNetworkForkingConfig,
   HardhatNetworkMiningConfig,
   HardhatNetworkMiningUserConfig,
+  HardhatNetworkMempoolConfig,
+  HardhatNetworkMempoolUserConfig,
   HardhatNetworkUserConfig,
   HardhatUserConfig,
   HDAccountsUserConfig,
@@ -228,10 +230,12 @@ function resolveHttpNetworkConfig(
 function resolveMiningConfig(
   userConfig: HardhatNetworkMiningUserConfig | undefined
 ): HardhatNetworkMiningConfig {
+  const mempool = resolveMempoolConfig(userConfig?.mempool);
   if (userConfig === undefined) {
     return {
       auto: true,
       interval: 0,
+      mempool,
     };
   }
 
@@ -241,6 +245,7 @@ function resolveMiningConfig(
     return {
       auto: true,
       interval: 0,
+      mempool,
     };
   }
 
@@ -248,6 +253,7 @@ function resolveMiningConfig(
     return {
       auto: false,
       interval,
+      mempool,
     };
   }
 
@@ -255,6 +261,7 @@ function resolveMiningConfig(
     return {
       auto,
       interval: 0,
+      mempool,
     };
   }
 
@@ -262,7 +269,28 @@ function resolveMiningConfig(
   return {
     auto: auto!,
     interval: interval!,
+    mempool,
   };
+}
+
+function resolveMempoolConfig(
+  userConfig: HardhatNetworkMempoolUserConfig | undefined
+): HardhatNetworkMempoolConfig {
+  if (userConfig === undefined) {
+    return {
+      order: "priority",
+    };
+  }
+
+  if (userConfig.order === undefined) {
+    return {
+      order: "priority",
+    };
+  }
+
+  return {
+    order: userConfig.order,
+  } as HardhatNetworkMempoolConfig;
 }
 
 function resolveSolidityConfig(userConfig: HardhatUserConfig): SolidityConfig {

--- a/packages/hardhat-core/src/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-validation.ts
@@ -3,6 +3,7 @@ import { Context, getFunctionName, ValidationError } from "io-ts/lib";
 import { Reporter } from "io-ts/lib/Reporter";
 
 import {
+  HARDHAT_MEMPOOL_SUPPORTED_ORDERS,
   HARDHAT_NETWORK_NAME,
   HARDHAT_NETWORK_SUPPORTED_HARDFORKS,
 } from "../../constants";
@@ -176,6 +177,22 @@ const HardhatNetworkForkingConfig = t.type({
   blockNumber: optional(t.number),
 });
 
+const HardhatNetworkMempoolConfig = t.type({
+  order: optional(
+    t.keyof(
+      fromEntries(
+        HARDHAT_MEMPOOL_SUPPORTED_ORDERS.map((order) => [order, null])
+      )
+    )
+  ),
+});
+
+const HardhatNetworkMiningConfig = t.type({
+  auto: optional(t.boolean),
+  interval: optional(t.union([t.number, t.tuple([t.number, t.number])])),
+  mempool: optional(HardhatNetworkMempoolConfig),
+});
+
 const commonNetworkConfigFields = {
   chainId: optional(t.number),
   from: optional(t.string),
@@ -202,6 +219,7 @@ const HardhatNetworkConfig = t.type({
   initialDate: optional(t.string),
   loggingEnabled: optional(t.boolean),
   forking: optional(HardhatNetworkForkingConfig),
+  mining: optional(HardhatNetworkMiningConfig),
 });
 
 const HDAccountsConfig = t.type({

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -42,7 +42,13 @@ export const defaultHardhatNetworkParams: Omit<
   throwOnTransactionFailures: true,
   throwOnCallFailures: true,
   allowUnlimitedContractSize: false,
-  mining: { auto: true, interval: 0 },
+  mining: {
+    auto: true,
+    interval: 0,
+    mempool: {
+      order: "priority",
+    },
+  },
   accounts: defaultHardhatNetworkHdAccountsConfigParams,
   loggingEnabled: false,
   gasMultiplier: DEFAULT_GAS_MULTIPLIER,

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -88,6 +88,7 @@ export function createProvider(
       hardhatNetConfig.throwOnCallFailures,
       hardhatNetConfig.mining.auto,
       hardhatNetConfig.mining.interval,
+      hardhatNetConfig.mining.mempool.order,
       new ModulesLogger(hardhatNetConfig.loggingEnabled),
       accounts,
       artifacts,

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -13,7 +13,10 @@ import type {
 } from "../../../types";
 import { HARDHAT_NETWORK_NAME } from "../../constants";
 import { ModulesLogger } from "../../hardhat-network/provider/modules/logger";
-import { ForkConfig } from "../../hardhat-network/provider/node-types";
+import {
+  ForkConfig,
+  MempoolOrder,
+} from "../../hardhat-network/provider/node-types";
 import { getForkCacheDirPath } from "../../hardhat-network/provider/utils/disk-cache";
 import { parseDateString } from "../../util/date";
 
@@ -88,7 +91,8 @@ export function createProvider(
       hardhatNetConfig.throwOnCallFailures,
       hardhatNetConfig.mining.auto,
       hardhatNetConfig.mining.interval,
-      hardhatNetConfig.mining.mempool.order,
+      // This cast is valid because of the config validation and resolution
+      hardhatNetConfig.mining.mempool.order as MempoolOrder,
       new ModulesLogger(hardhatNetConfig.loggingEnabled),
       accounts,
       artifacts,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/TransactionQueue.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/TransactionQueue.ts
@@ -2,7 +2,8 @@ import { TypedTransaction } from "@ethereumjs/tx";
 import { BN } from "ethereumjs-util";
 import Heap from "mnemonist/heap";
 
-import { InternalError } from "../../core/providers/errors";
+import { InternalError, InvalidInputError } from "../../core/providers/errors";
+import { MempoolOrder } from "./node-types";
 import { OrderedTransaction } from "./PoolState";
 
 function getEffectiveMinerFee(tx: OrderedTransaction, baseFee?: BN): BN {
@@ -38,6 +39,33 @@ function decreasingOrderEffectiveMinerFeeComparator(
   // in increasing order by orderId.
   return left.orderId - right.orderId;
 }
+
+function decreasingOrderComparator(
+  left: OrderedTransaction,
+  right: OrderedTransaction
+) {
+  return left.orderId - right.orderId;
+}
+
+function getOrderedTransactionHeap(
+  mempoolOrder: MempoolOrder,
+  baseFee?: BN
+): Heap<OrderedTransaction> {
+  switch (mempoolOrder) {
+    case "priority":
+      return new Heap<OrderedTransaction>((a, b) =>
+        decreasingOrderEffectiveMinerFeeComparator(a, b, baseFee)
+      );
+    case "fifo":
+      return new Heap<OrderedTransaction>((a, b) =>
+        decreasingOrderComparator(a, b)
+      );
+    default:
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new InvalidInputError(`Invalid mempool order: ${mempoolOrder}`);
+  }
+}
+
 /**
  * A queue of transactions in the order that they could be mined in the next
  * block.
@@ -67,11 +95,10 @@ export class TransactionQueue {
    */
   constructor(
     pendingTransactions: Map<string, OrderedTransaction[]>,
+    mempoolOrder: MempoolOrder,
     baseFee?: BN
   ) {
-    this._heap = new Heap<OrderedTransaction>((a, b) =>
-      decreasingOrderEffectiveMinerFeeComparator(a, b, baseFee)
-    );
+    this._heap = getOrderedTransactionHeap(mempoolOrder, baseFee);
 
     for (const [address, txList] of pendingTransactions) {
       if (baseFee === undefined && txList.some((tx) => tx.data.type === 2)) {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -3,6 +3,7 @@ import { RunBlockResult } from "@ethereumjs/vm/dist/runBlock";
 import { BN } from "ethereumjs-util";
 
 import { BuildInfo } from "../../../types";
+import { HARDHAT_MEMPOOL_SUPPORTED_ORDERS } from "../../constants";
 import { MessageTrace } from "../stack-traces/message-trace";
 
 import type { ReturnData } from "./return-data";
@@ -28,6 +29,7 @@ interface CommonConfig {
   initialDate?: Date;
   tracingConfig?: TracingConfig;
   initialBaseFeePerGas?: number;
+  mempoolOrder: MempoolOrder;
 }
 
 export type LocalNodeConfig = CommonConfig;
@@ -47,6 +49,8 @@ export interface TracingConfig {
 }
 
 export type IntervalMiningConfig = number | [number, number];
+
+export type MempoolOrder = typeof HARDHAT_MEMPOOL_SUPPORTED_ORDERS[number];
 
 export interface GenesisAccount {
   privateKey: string;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -82,6 +82,7 @@ import {
   GatherTracesResult,
   GenesisAccount,
   isForkedNodeConfig,
+  MempoolOrder,
   MineBlockResult,
   NodeConfig,
   RunCallResult,
@@ -132,6 +133,7 @@ export class HardhatNode extends EventEmitter {
       allowUnlimitedContractSize,
       tracingConfig,
       minGasPrice,
+      mempoolOrder,
     } = config;
 
     let common: Common;
@@ -242,6 +244,7 @@ export class HardhatNode extends EventEmitter {
       automine,
       minGasPrice,
       initialBlockTimeOffset,
+      mempoolOrder,
       genesisAccounts,
       tracingConfig,
       forkNetworkId,
@@ -315,6 +318,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     private _automine: boolean,
     private _minGasPrice: BN,
     private _blockTimeOffsetSeconds: BN = new BN(0),
+    private _mempoolOrder: MempoolOrder,
     genesisAccounts: GenesisAccount[],
     tracingConfig?: TracingConfig,
     private _forkNetworkId?: number,
@@ -1579,6 +1583,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       const pendingTxs = this._txPool.getPendingTransactions();
       const transactionQueue = new TransactionQueue(
         pendingTxs,
+        this._mempoolOrder,
         headerData.baseFeePerGas
       );
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -40,6 +40,7 @@ import {
   ForkConfig,
   GenesisAccount,
   IntervalMiningConfig,
+  MempoolOrder,
   NodeConfig,
   TracingConfig,
 } from "./node-types";
@@ -81,6 +82,7 @@ export class HardhatNetworkProvider
     private readonly _throwOnCallFailures: boolean,
     private readonly _automine: boolean,
     private readonly _intervalMining: IntervalMiningConfig,
+    private readonly _mempoolOrder: MempoolOrder,
     private readonly _logger: ModulesLogger,
     private readonly _genesisAccounts: GenesisAccount[] = [],
     private readonly _artifacts?: Artifacts,
@@ -227,6 +229,7 @@ export class HardhatNetworkProvider
       allowUnlimitedContractSize: this._allowUnlimitedContractSize,
       tracingConfig: await this._makeTracingConfig(),
       initialBaseFeePerGas: this._initialBaseFeePerGas,
+      mempoolOrder: this._mempoolOrder,
       hardfork: this._hardfork,
       networkName: this._networkName,
       chainId: this._chainId,

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -13,6 +13,7 @@
 // trying to augment the config types.
 
 import type { BN } from "ethereumjs-util";
+import { HARDHAT_MEMPOOL_SUPPORTED_ORDERS } from "../internal/constants";
 
 // Networks config
 
@@ -170,11 +171,22 @@ export interface HttpNetworkHDAccountsConfig {
 export interface HardhatNetworkMiningConfig {
   auto: boolean;
   interval: number | [number, number];
+  mempool: HardhatNetworkMempoolConfig;
 }
 
 export interface HardhatNetworkMiningUserConfig {
   auto?: boolean;
   interval?: number | [number, number];
+  mempool?: HardhatNetworkMempoolUserConfig;
+}
+
+export interface HardhatNetworkMempoolConfig {
+  // order should be on of `HARDHAT_MEMPOOL_SUPPORTED_ORDERS` entries
+  order: typeof HARDHAT_MEMPOOL_SUPPORTED_ORDERS[number];
+}
+
+export interface HardhatNetworkMempoolUserConfig {
+  order?: string;
 }
 
 // Project paths config

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -13,12 +13,12 @@
 // trying to augment the config types.
 
 import type { BN } from "ethereumjs-util";
-import { HARDHAT_MEMPOOL_SUPPORTED_ORDERS } from "../internal/constants";
 
 // Networks config
 
 export interface NetworksUserConfig {
   hardhat?: HardhatNetworkUserConfig;
+
   [networkName: string]: NetworkUserConfig | undefined;
 }
 
@@ -96,6 +96,7 @@ export interface HttpNetworkUserConfig {
 export interface NetworksConfig {
   hardhat: HardhatNetworkConfig;
   localhost: HttpNetworkConfig;
+
   [networkName: string]: NetworkConfig;
 }
 
@@ -181,8 +182,7 @@ export interface HardhatNetworkMiningUserConfig {
 }
 
 export interface HardhatNetworkMempoolConfig {
-  // order should be on of `HARDHAT_MEMPOOL_SUPPORTED_ORDERS` entries
-  order: typeof HARDHAT_MEMPOOL_SUPPORTED_ORDERS[number];
+  order: string; // Guaranteed at runtime to be have a valid value
 }
 
 export interface HardhatNetworkMempoolUserConfig {

--- a/packages/hardhat-core/test/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-resolution.ts
@@ -502,6 +502,9 @@ describe("Config resolution", () => {
           assert.deepEqual(config.networks.hardhat.mining, {
             auto: true,
             interval: 0,
+            mempool: {
+              order: "priority",
+            },
           });
         });
 
@@ -519,10 +522,13 @@ describe("Config resolution", () => {
           assert.deepEqual(config.networks.hardhat.mining, {
             auto: false,
             interval: 1000,
+            mempool: {
+              order: "priority",
+            },
           });
         });
 
-        it("should allow cofiguring only automine", function () {
+        it("should allow configuring only automine", function () {
           const config = resolveConfig(__filename, {
             networks: {
               hardhat: {
@@ -536,10 +542,13 @@ describe("Config resolution", () => {
           assert.deepEqual(config.networks.hardhat.mining, {
             auto: false,
             interval: 0,
+            mempool: {
+              order: "priority",
+            },
           });
         });
 
-        it("should allow cofiguring both values", function () {
+        it("should allow configuring both values", function () {
           const config = resolveConfig(__filename, {
             networks: {
               hardhat: {
@@ -554,6 +563,9 @@ describe("Config resolution", () => {
           assert.deepEqual(config.networks.hardhat.mining, {
             auto: true,
             interval: 1000,
+            mempool: {
+              order: "priority",
+            },
           });
         });
 
@@ -571,6 +583,31 @@ describe("Config resolution", () => {
           assert.deepEqual(config.networks.hardhat.mining, {
             auto: false,
             interval: [1000, 5000],
+            mempool: {
+              order: "priority",
+            },
+          });
+        });
+
+        it("should set the mempool order", function () {
+          const config = resolveConfig(__filename, {
+            networks: {
+              hardhat: {
+                mining: {
+                  mempool: {
+                    order: "fifo",
+                  },
+                },
+              },
+            },
+          });
+
+          assert.deepEqual(config.networks.hardhat.mining, {
+            auto: true,
+            interval: 0,
+            mempool: {
+              order: "fifo",
+            },
           });
         });
       });
@@ -633,6 +670,9 @@ describe("Config resolution", () => {
           mining: {
             auto: false,
             interval: 0,
+            mempool: {
+              order: "priority",
+            },
           },
           hardfork: "hola",
           initialDate: "today",

--- a/packages/hardhat-core/test/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-validation.ts
@@ -991,6 +991,103 @@ describe("Config validation", function () {
             );
           });
         });
+
+        describe("HardhatNetworkMempoolConfig", function () {
+          it("Should accept a valid Mempool config", function () {
+            validateConfig({
+              networks: {
+                [HARDHAT_NETWORK_NAME]: {
+                  mining: {
+                    auto: true,
+                    interval: 0,
+                  },
+                },
+              },
+            });
+
+            validateConfig({
+              networks: {
+                [HARDHAT_NETWORK_NAME]: {
+                  mining: {
+                    auto: true,
+                    interval: [10, 100],
+                  },
+                },
+              },
+            });
+
+            validateConfig({
+              networks: {
+                [HARDHAT_NETWORK_NAME]: {
+                  mining: {
+                    mempool: {
+                      order: "priority",
+                    },
+                  },
+                },
+              },
+            });
+
+            validateConfig({
+              networks: {
+                [HARDHAT_NETWORK_NAME]: {
+                  mining: {
+                    mempool: {
+                      order: "fifo",
+                    },
+                  },
+                },
+              },
+            });
+          });
+
+          it("Should fail with invalid types", function () {
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      mining: {
+                        auto: "not-supported",
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      mining: {
+                        auto: true,
+                        interval: "not-supported",
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      mining: {
+                        mempool: {
+                          order: "not-supported",
+                        },
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+          });
+        });
       });
 
       describe("HTTP network config", function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -1,4 +1,8 @@
 import { BN, bufferToHex, privateToAddress, toBuffer } from "ethereumjs-util";
+import {
+  HardhatNetworkMempoolConfig,
+  HardhatNetworkMiningConfig,
+} from "../../../../src/types";
 
 import { ALCHEMY_URL, INFURA_URL } from "../../../setup";
 
@@ -11,9 +15,14 @@ export const DEFAULT_NETWORK_ID = 234;
 export const DEFAULT_BLOCK_GAS_LIMIT = 6000000;
 export const DEFAULT_USE_JSON_RPC = false;
 export const DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE = false;
-export const DEFAULT_MINING_CONFIG = {
+
+export const DEFAULT_MEMPOOL_CONFIG: HardhatNetworkMempoolConfig = {
+  order: "priority",
+};
+export const DEFAULT_MINING_CONFIG: HardhatNetworkMiningConfig = {
   auto: true,
   interval: 0,
+  mempool: DEFAULT_MEMPOOL_CONFIG,
 };
 
 // Assumptions:
@@ -83,6 +92,7 @@ export const INTERVAL_MINING_PROVIDERS = [
         mining: {
           auto: false,
           interval: 10000,
+          mempool: DEFAULT_MEMPOOL_CONFIG,
         },
         ...options,
       });
@@ -99,6 +109,7 @@ export const INTERVAL_MINING_PROVIDERS = [
         mining: {
           auto: false,
           interval: 10000,
+          mempool: DEFAULT_MEMPOOL_CONFIG,
         },
         ...options,
       });
@@ -143,6 +154,7 @@ if (ALCHEMY_URL !== undefined) {
         mining: {
           auto: false,
           interval: 10000,
+          mempool: DEFAULT_MEMPOOL_CONFIG,
         },
         ...options,
       });

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -6,6 +6,7 @@ import { ForkConfig } from "../../../../src/internal/hardhat-network/provider/no
 import { HardhatNetworkProvider } from "../../../../src/internal/hardhat-network/provider/provider";
 import {
   EthereumProvider,
+  HardhatNetworkMempoolConfig,
   HardhatNetworkMiningConfig,
 } from "../../../../src/types";
 
@@ -19,6 +20,7 @@ import {
   DEFAULT_MINING_CONFIG,
   DEFAULT_NETWORK_ID,
   DEFAULT_NETWORK_NAME,
+  DEFAULT_MEMPOOL_CONFIG,
   DEFAULT_USE_JSON_RPC,
 } from "./providers";
 
@@ -45,6 +47,7 @@ export interface UseProviderOptions {
   accounts?: Array<{ privateKey: string; balance: BN }>;
   allowUnlimitedContractSize?: boolean;
   initialBaseFeePerGas?: number;
+  mempool?: HardhatNetworkMempoolConfig;
 }
 
 export function useProvider({
@@ -60,6 +63,7 @@ export function useProvider({
   accounts = DEFAULT_ACCOUNTS,
   allowUnlimitedContractSize = DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
   initialBaseFeePerGas,
+  mempool = DEFAULT_MEMPOOL_CONFIG,
 }: UseProviderOptions = {}) {
   beforeEach("Initialize provider", async function () {
     this.logger = new FakeModulesLogger(loggerEnabled);
@@ -75,6 +79,7 @@ export function useProvider({
       true,
       mining.auto,
       mining.interval,
+      mempool.order,
       this.logger,
       accounts,
       undefined,

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -2,7 +2,10 @@ import { BN } from "ethereumjs-util";
 
 import { BackwardsCompatibilityProviderAdapter } from "../../../../src/internal/core/providers/backwards-compatibility";
 import { JsonRpcServer } from "../../../../src/internal/hardhat-network/jsonrpc/server";
-import { ForkConfig } from "../../../../src/internal/hardhat-network/provider/node-types";
+import {
+  ForkConfig,
+  MempoolOrder,
+} from "../../../../src/internal/hardhat-network/provider/node-types";
 import { HardhatNetworkProvider } from "../../../../src/internal/hardhat-network/provider/provider";
 import {
   EthereumProvider,
@@ -79,7 +82,7 @@ export function useProvider({
       true,
       mining.auto,
       mining.interval,
-      mempool.order,
+      mempool.order as MempoolOrder,
       this.logger,
       accounts,
       undefined,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/TransactionQueue.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/TransactionQueue.ts
@@ -56,7 +56,7 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
         });
 
         assert.throws(
-          () => new TransactionQueue(makeOrderedTxMap([tx1])),
+          () => new TransactionQueue(makeOrderedTxMap([tx1]), "priority"),
           InternalError
         );
       });
@@ -81,7 +81,7 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
 
           const txs = [tx1, tx2, tx3, tx4];
           txs.sort(weakRandomComparator);
-          const queue = new TransactionQueue(makeOrderedTxMap(txs));
+          const queue = new TransactionQueue(makeOrderedTxMap(txs), "priority");
 
           assert.equal(queue.getNextTransaction(), tx4.data);
           assert.equal(queue.getNextTransaction(), tx2.data);
@@ -155,7 +155,7 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
 
         const txs = [tx1, tx2, tx3, tx4, tx5, tx6, tx7, tx8, tx9, tx10];
         txs.sort(weakRandomComparator);
-        const queue = new TransactionQueue(makeOrderedTxMap(txs));
+        const queue = new TransactionQueue(makeOrderedTxMap(txs), "priority");
 
         assert.equal(queue.getNextTransaction(), tx1.data);
         assert.equal(queue.getNextTransaction(), tx2.data);
@@ -182,7 +182,8 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
         });
 
         assert.doesNotThrow(
-          () => new TransactionQueue(makeOrderedTxMap([tx1]), new BN(1))
+          () =>
+            new TransactionQueue(makeOrderedTxMap([tx1]), "priority", new BN(1))
         );
       });
     });
@@ -217,7 +218,11 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
 
         const txs = [tx1, tx2, tx3, tx4, tx5];
         txs.sort(weakRandomComparator);
-        const queue = new TransactionQueue(makeOrderedTxMap(txs), baseFee);
+        const queue = new TransactionQueue(
+          makeOrderedTxMap(txs),
+          "priority",
+          baseFee
+        );
 
         assert.equal(queue.getNextTransaction(), tx5.data);
         assert.equal(queue.getNextTransaction(), tx4.data);
@@ -307,7 +312,11 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
 
         const txs = [tx1, tx2, tx3, tx4, tx5, tx6, tx7, tx8, tx9, tx10];
         txs.sort(weakRandomComparator);
-        const queue = new TransactionQueue(makeOrderedTxMap(txs), baseFee);
+        const queue = new TransactionQueue(
+          makeOrderedTxMap(txs),
+          "priority",
+          baseFee
+        );
 
         assert.equal(queue.getNextTransaction(), tx1.data);
         assert.equal(queue.getNextTransaction(), tx2.data);

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/TransactionQueue.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/TransactionQueue.ts
@@ -231,6 +231,36 @@ describe(`TxPriorityHeap (tests using seed ${bufferToHex(SEED)})`, () => {
         assert.equal(queue.getNextTransaction(), tx1.data);
       });
 
+      it("Should use the order to sort txs in FIFO mode", function () {
+        const baseFee = new BN(15);
+
+        // Effective miner fee: 96
+        const tx1 = createTestTransaction({ gasPrice: 111 });
+
+        // Effective miner fee: 100
+        const tx2 = createTestTransaction({
+          maxFeePerGas: 120,
+          maxPriorityFeePerGas: 100,
+        });
+
+        // Effective miner fee: 110
+        const tx3 = createTestTransaction({
+          maxFeePerGas: 140,
+          maxPriorityFeePerGas: 110,
+        });
+
+        const txs = [tx1, tx2, tx3];
+        const queue = new TransactionQueue(
+          makeOrderedTxMap(txs),
+          "fifo",
+          baseFee
+        );
+
+        assert.equal(queue.getNextTransaction(), tx1.data);
+        assert.equal(queue.getNextTransaction(), tx2.data);
+        assert.equal(queue.getNextTransaction(), tx3.data);
+      });
+
       it("Should not include transactions from a sender whose next tx was discarded", function () {
         const baseFee = new BN(20);
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -182,6 +182,7 @@ describe("Debug module", function () {
         true,
         false, // mining.auto
         0, // mining.interval
+        "priority", // mining.mempool.order
         logger,
         DEFAULT_ACCOUNTS,
         undefined,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -54,6 +54,7 @@ describe("HardhatNode", () => {
     minGasPrice: new BN(0),
     genesisAccounts: DEFAULT_ACCOUNTS,
     initialBaseFeePerGas: 10,
+    mempoolOrder: "priority",
   };
   const gasPrice = 20;
   let node: HardhatNode;
@@ -168,6 +169,39 @@ describe("HardhatNode", () => {
         await assertTransactionsWereMined([tx1, tx2]);
         const balance = await node.getAccountBalance(EMPTY_ACCOUNT_ADDRESS);
         assert.equal(balance.toString(), "2468");
+      });
+
+      it("can keep the transaction ordering when mining a block", async () => {
+        [, node] = await HardhatNode.create({
+          ...config,
+          mempoolOrder: "fifo",
+        });
+
+        const tx1 = createTestTransaction({
+          nonce: 0,
+          from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+          to: EMPTY_ACCOUNT_ADDRESS,
+          gasLimit: 21_000,
+          value: 1234,
+          gasPrice: 42,
+        });
+        const tx2 = createTestTransaction({
+          nonce: 0,
+          from: DEFAULT_ACCOUNTS_ADDRESSES[1],
+          to: EMPTY_ACCOUNT_ADDRESS,
+          gasLimit: 21_000,
+          value: 1234,
+          gasPrice: 84,
+        });
+        await node.sendTransaction(tx1);
+        await node.sendTransaction(tx2);
+        await node.mineBlock();
+
+        const txReceipt1 = await node.getTransactionReceipt(tx1.hash());
+        const txReceipt2 = await node.getTransactionReceipt(tx2.hash());
+
+        assert.equal(txReceipt1?.transactionIndex, "0x0");
+        assert.equal(txReceipt2?.transactionIndex, "0x1");
       });
 
       it("can mine a block with two transactions from the same sender", async () => {
@@ -680,6 +714,7 @@ describe("HardhatNode", () => {
           blockGasLimit: rpcBlock.gasLimit.toNumber(),
           minGasPrice: new BN(0),
           genesisAccounts: [],
+          mempoolOrder: "priority",
         };
 
         const [common, forkedNode] = await HardhatNode.create(forkedNodeConfig);


### PR DESCRIPTION
This adds a new parameter to the Hardhat config: `networks.hardhat.txpool` which can be an object:
```ts
{
  fifo: boolean;
}
```

Setting `fifo` to `true` will overwrite the default txpool ordering, so that transactions are mined in a FIFO queue.

This is especially useful when using the fork feature of Hardhat (great feature BTW), if you want to replay a block up to a certain point. Since some blocks on ETH mainnet are not ordered by decreasing gasprice anymore (cf. Flashbots), we have to find a way for the user to mine transactions in a specific, non-traditional, order.

I'm not sure about the naming of the config though...