### PR TITLE
Fix the returned cumulative gas used and log index in transaction receipts

### DIFF
--- a/.changeset/orange-brooms-prove.md
+++ b/.changeset/orange-brooms-prove.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed how the cummulative gas is computed for receipts and added a missing field (Thanks @ngotchac!)

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/log.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/log.ts
@@ -6,6 +6,7 @@ import { rpcAddress, rpcData, rpcHash, rpcQuantity } from "../base-types";
 export type RpcLog = t.TypeOf<typeof rpcLog>;
 export const rpcLog = t.type(
   {
+    logIndex: nullable(rpcQuantity),
     transactionIndex: nullable(rpcQuantity),
     transactionHash: nullable(rpcHash),
     blockHash: nullable(rpcHash),

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -215,9 +215,7 @@ export class ForkBlockchain implements HardhatBlockchainInterface {
             : filterParams.addresses,
         topics: filterParams.normalizedTopics,
       });
-      return remoteLogs
-        .map((log, index) => toRpcLogOutput(log, index))
-        .concat(localLogs);
+      return remoteLogs.map(toRpcLogOutput).concat(localLogs);
     }
     return this._data.getLogs(filterParams);
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
@@ -395,7 +395,7 @@ export function remoteReceiptToRpcReceiptOutput(
   };
 }
 
-export function toRpcLogOutput(log: RpcLog, index?: number): RpcLogOutput {
+export function toRpcLogOutput(log: RpcLog): RpcLogOutput {
   return {
     removed: false,
     address: bufferToRpcData(log.address),
@@ -403,7 +403,7 @@ export function toRpcLogOutput(log: RpcLog, index?: number): RpcLogOutput {
     blockNumber:
       log.blockNumber !== null ? numberToRpcQuantity(log.blockNumber) : null,
     data: bufferToRpcData(log.data),
-    logIndex: index !== undefined ? numberToRpcQuantity(index) : null,
+    logIndex: log.logIndex !== null ? numberToRpcQuantity(log.logIndex) : null,
     transactionIndex:
       log.transactionIndex !== null
         ? numberToRpcQuantity(log.transactionIndex)

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
@@ -292,18 +292,18 @@ export function getRpcReceiptOutputsFromLocalBlockExecution(
 ): RpcReceiptOutput[] {
   const receipts: RpcReceiptOutput[] = [];
 
-  let cumulativeGasUsed = new BN(0);
+  let blockLogIndex = 0;
 
   for (let i = 0; i < runBlockResult.results.length; i += 1) {
     const tx = block.transactions[i];
     const { createdAddress, gasUsed } = runBlockResult.results[i];
     const receipt = runBlockResult.receipts[i];
 
-    cumulativeGasUsed = cumulativeGasUsed.add(new BN(receipt.gasUsed));
-
-    const logs = receipt.logs.map((log, logIndex) =>
-      getRpcLogOutput(log, tx, block, i, logIndex)
-    );
+    const logs = receipt.logs.map((log) => {
+      const result = getRpcLogOutput(log, tx, block, i, blockLogIndex);
+      blockLogIndex += 1;
+      return result;
+    });
 
     const rpcReceipt: RpcReceiptOutput = {
       transactionHash: bufferToRpcData(tx.hash()),
@@ -312,7 +312,7 @@ export function getRpcReceiptOutputsFromLocalBlockExecution(
       blockNumber: numberToRpcQuantity(new BN(block.header.number)),
       from: bufferToRpcData(tx.getSenderAddress().toBuffer()),
       to: tx.to === undefined ? null : bufferToRpcData(tx.to.toBuffer()),
-      cumulativeGasUsed: numberToRpcQuantity(cumulativeGasUsed),
+      cumulativeGasUsed: numberToRpcQuantity(new BN(receipt.gasUsed)),
       gasUsed: numberToRpcQuantity(gasUsed),
       contractAddress:
         createdAddress !== undefined

--- a/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
@@ -459,9 +459,9 @@ describe("JsonRpcClient", () => {
             const logs = await client.getLogs({
               fromBlock: BLOCK_NUMBER_OF_10496585,
               toBlock: BLOCK_NUMBER_OF_10496585,
-              address: toBuffer("0x5acc84a3e955bdd76467d3348077d003f00ffb97"),
+              address: toBuffer("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
             });
-            assert.equal(logs.length, 19);
+            assert.equal(logs.length, 12);
           });
         });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -600,13 +600,31 @@ describe("ForkBlockchain", () => {
     });
 
     it("supports remote blocks", async () => {
+      // See results at https://api.etherscan.io/api?module=logs&action=getLogs&fromBlock=10496585&toBlock=10496585&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
       const logs = await fb.getLogs({
         fromBlock: BLOCK_NUMBER_OF_10496585,
         toBlock: BLOCK_NUMBER_OF_10496585,
-        addresses: [toBuffer("0x5acc84a3e955bdd76467d3348077d003f00ffb97")],
+        addresses: [toBuffer("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")],
         normalizedTopics: [],
       });
-      assert.equal(logs.length, 19);
+      assert.equal(logs.length, 12);
+      assert.deepEqual(
+        logs.map((l) => l.logIndex),
+        [
+          "0x1",
+          "0x4",
+          "0xd",
+          "0xe",
+          "0x11",
+          "0x14",
+          "0x1b",
+          "0x1e",
+          "0x29",
+          "0x2a",
+          "0x8b",
+          "0x8c",
+        ]
+      );
     });
 
     it("can fetch both remote and local logs simultaneously", async () => {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

Please consider the checklist items below, keep the ones that make sense for your PR, and delete the ones that don't.  If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.
-->

- [x] (this PR includes a **bug fix**) Relevant tests have been included.

---
It seems that the cumulativeGasUsed and logIndex fields in transaction receipts were not correct.

For cumulativeGasUsed: the `gas` field of the receipt is actually already the `cumulativeGasUsed` ; so we can use it directly,
or compute it from the `gasUsed` value of the result.

For the logIndex, it actually isn't per transaction, but within a block.

Note : how `logIndex` should be set is not actually in the specs, but that's how it's commonly implemented, cf. [Geth implementation](https://github.com/ethereum/go-ethereum/blob/87a11a87c2bcbeedce9e088698b48d8fa2a09450/core/types/receipt.go#L272-L314)
