### PR TITLE
Use the right `sender` when tracing a transaction

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -1234,16 +1234,22 @@ Hardhat Network's forking functionality only works with blocks from at least spu
 
         for (const tx of block.transactions) {
           let txWithCommon: TypedTransaction;
+          const sender = tx.getSenderAddress();
           if (tx.type === 0) {
-            txWithCommon = new Transaction(tx, {
+            txWithCommon = new FakeSenderTransaction(sender, tx, {
               common: vm._common,
             });
           } else if (tx.type === 1) {
-            txWithCommon = new AccessListEIP2930Transaction(tx, {
-              common: vm._common,
-            });
+            txWithCommon = new FakeSenderAccessListEIP2930Transaction(
+              sender,
+              tx,
+              {
+                common: vm._common,
+              }
+            );
           } else if (tx.type === 2) {
-            txWithCommon = new FeeMarketEIP1559Transaction(
+            txWithCommon = new FakeSenderEIP1559Transaction(
+              sender,
               { ...tx, gasPrice: undefined },
               {
                 common: vm._common,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -66,6 +66,40 @@ describe("Debug module", function () {
           });
         });
 
+        it("Should return the right values for fake sender txs", async function () {
+          const impersonatedAddress =
+            "0xC014BA5EC014ba5ec014Ba5EC014ba5Ec014bA5E";
+
+          await this.provider.send("eth_sendTransaction", [
+            {
+              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              to: impersonatedAddress,
+              value: "0x100",
+            },
+          ]);
+
+          await this.provider.send("hardhat_impersonateAccount", [
+            impersonatedAddress,
+          ]);
+
+          const txHash = await this.provider.send("eth_sendTransaction", [
+            {
+              from: impersonatedAddress,
+              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+            },
+          ]);
+          const trace: RpcDebugTraceOutput = await this.provider.send(
+            "debug_traceTransaction",
+            [txHash]
+          );
+          assert.deepEqual(trace, {
+            gas: 21000,
+            failed: false,
+            returnValue: "",
+            structLogs: [],
+          });
+        });
+
         it("Should return the right values for successful contract tx", async function () {
           const contractAddress = await deployContract(
             this.provider,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

Please consider the checklist items below, keep the ones that make sense for your PR, and delete the ones that don't.  If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.
-->

- [ ] (If this PR includes a **documentation change**) This PR's branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [ ] (If this PR includes a **bug fix**) Relevant tests have been included.
- [ ] (If this PR includes a **new feature**) The change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I haven't added tests yet, but I wanted to be sure this was the right way to do it first.

So the issue was that, when tracing tracing transactions that was sent using `impersonate_account`, the sender was getting lost and the trace resulted in something completely different if the transaction is checking for the sender (eg. in a `onlyOwner` modifier).
