### PR TITLE
Fix LATEST_DEPENDENCY_VERSIONS workflow

### DIFF
--- a/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
+++ b/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
@@ -1,4 +1,4 @@
-name: LATEST_DEPENDENCY_VERSIONS
+name: Run the entire test suite with the latest dependency versions
 
 on:
   schedule:
@@ -11,23 +11,13 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - name: install vyper
-        run: docker pull ethereum/vyper:0.1.0b10
+        run: docker pull vyperlang/vyper:0.1.0b10
       - uses: actions/checkout@v2
-      - name: Install node-gyp-cache
-        run: |
-          yarn global add node-gyp-cache
-          yarn config set node_gyp node-gyp-cache
       - name: Delete yarn.lock
         run: "rm yarn.lock"
       - name: Install
         run: yarn
       - name: Run tests
-        env:
-          INFURA_URL: ${{ secrets.INFURA_URL }}
-          ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
-          DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
-          NODE_OPTIONS: "--max_old_space_size=4096"
-          FORCE_COLOR: 3
         run: yarn test


### PR DESCRIPTION
This PR fixes a Github Actions workflow that's run with the latest version of every dependency.  This workflow is scheduled to run every 8 hours.

The changes are:
- Upgrade node to version 12, as solcjs has a bug with node 10.
- Install the correct docker image of vyper
- Stop installing `node-gyp-cache`
- Use a better workflow name. No idea why I used a THAT_NAME in the first place.
- Removed the forking-related tests, as those are too unstable to run in a cron job, and those don't use anything new wrt dependencies.

Note that I tested the workflow by making it run on push, and then rebased this PR.
