### PR TITLE
[feat] Add Polygon testnet support

### DIFF
--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -35,6 +35,7 @@ enum NetworkID {
   OPTIMISTIC_KOVAN = 69,
   // Polygon
   POLYGON = 137,
+  POLYGON_MUMBAI = 80001,
 }
 
 const networkIDtoEndpoints: NetworkMap = {
@@ -89,6 +90,10 @@ const networkIDtoEndpoints: NetworkMap = {
   [NetworkID.POLYGON]: {
     apiURL: "https://api.polygonscan.com/api",
     browserURL: "https://polygonscan.com",
+  },
+  [NetworkID.POLYGON_MUMBAI]: {
+    apiURL: "https://api-testnet.polygonscan.com/api",
+    browserURL: "https://mumbai.polygonscan.com/"
   },
 };
 


### PR DESCRIPTION
Quick PR to add support for polygon's testnet on `hardhat-etherscan`, using the api found [here](https://mumbai.polygonscan.com/apis#contracts).

The PR was based off of the previous work done in #1532 (thanks @BrknRobot !)