### PR TITLE
Add hardhat-change-network to plugin list

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -345,6 +345,14 @@ const plugins = [
       "Scripts",
     ],
   },
+  {
+    name: "hardhat-change-network",
+    author: "David Mihal",
+    authorUrl: "https://github.com/dmihal",
+    url: "https://github.com/dmihal/hardhat-change-network/tree/master",
+    description: "Allows changing the current network in Hardhat.",
+    tags: ["Testing"],
+  },
 ];
 
 module.exports = plugins.map((p) => ({


### PR DESCRIPTION
- [x ] (If this PR includes a **documentation change**) This PR's branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [ ] (If this PR includes a **bug fix**) Relevant tests have been included.
- [ ] (If this PR includes a **new feature**) The change was previously discussed on an Issue or with someone from the team.
- [] I didn't do anything of this.

---

Adds `hardhat-change-network` to the list of plugins
