### PR TITLE
Fix linter error for clean CI run

### DIFF
--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -93,7 +93,7 @@ const networkIDtoEndpoints: NetworkMap = {
   },
   [NetworkID.POLYGON_MUMBAI]: {
     apiURL: "https://api-testnet.polygonscan.com/api",
-    browserURL: "https://mumbai.polygonscan.com/"
+    browserURL: "https://mumbai.polygonscan.com/",
   },
 };
 


### PR DESCRIPTION
Because I noticed that CI was failing on the `master` branch.