### PR TITLE
Use absolute paths in eslint config files

### DIFF
--- a/packages/e2e/.eslintrc.js
+++ b/packages/e2e/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-core/.eslintrc.js
+++ b/packages/hardhat-core/.eslintrc.js
@@ -1,10 +1,10 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "src/tsconfig.json",
-    sourceType: "module",
+    project: `${__dirname}/src/tsconfig.json`,
+    sourceType: "module"
   },
   rules: {
-    "@nomiclabs/only-hardhat-error": "error",
-  },
+    "@nomiclabs/only-hardhat-error": "error"
+  }
 };

--- a/packages/hardhat-core/test/.eslintrc.js
+++ b/packages/hardhat-core/test/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/../tsconfig.json`,
     sourceType: "module",
   },
   rules: {

--- a/packages/hardhat-docker/.eslintrc.js
+++ b/packages/hardhat-docker/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-docker/test/.eslintrc.js
+++ b/packages/hardhat-docker/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-ethers/.eslintrc.js
+++ b/packages/hardhat-ethers/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "src/tsconfig.json",
+    project: `${__dirname}/src/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-ethers/test/.eslintrc.js
+++ b/packages/hardhat-ethers/test/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/../tsconfig.json`,
     sourceType: "module",
   },
   rules: {

--- a/packages/hardhat-etherscan/.eslintrc.js
+++ b/packages/hardhat-etherscan/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-etherscan/test/.eslintrc.js
+++ b/packages/hardhat-etherscan/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-ganache/.eslintrc.js
+++ b/packages/hardhat-ganache/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-ganache/test/.eslintrc.js
+++ b/packages/hardhat-ganache/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-shorthand/.eslintrc.js
+++ b/packages/hardhat-shorthand/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-shorthand/test/.eslintrc.js
+++ b/packages/hardhat-shorthand/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-solhint/.eslintrc.js
+++ b/packages/hardhat-solhint/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-solhint/test/.eslintrc.js
+++ b/packages/hardhat-solhint/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-solpp/.eslintrc.js
+++ b/packages/hardhat-solpp/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-solpp/test/.eslintrc.js
+++ b/packages/hardhat-solpp/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-truffle4/.eslintrc.js
+++ b/packages/hardhat-truffle4/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-truffle4/test/.eslintrc.js
+++ b/packages/hardhat-truffle4/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-truffle5/.eslintrc.js
+++ b/packages/hardhat-truffle5/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-truffle5/test/.eslintrc.js
+++ b/packages/hardhat-truffle5/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-vyper/.eslintrc.js
+++ b/packages/hardhat-vyper/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-vyper/test/.eslintrc.js
+++ b/packages/hardhat-vyper/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-waffle/.eslintrc.js
+++ b/packages/hardhat-waffle/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-waffle/test/.eslintrc.js
+++ b/packages/hardhat-waffle/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-web3-legacy/.eslintrc.js
+++ b/packages/hardhat-web3-legacy/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-web3-legacy/test/.eslintrc.js
+++ b/packages/hardhat-web3-legacy/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",

--- a/packages/hardhat-web3/.eslintrc.js
+++ b/packages/hardhat-web3/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["../../config/eslint/eslintrc.js"],
+  extends: [`${__dirname}/../../config/eslint/eslintrc.js`],
   parserOptions: {
-    project: "tsconfig.json",
+    project: `${__dirname}/tsconfig.json`,
     sourceType: "module",
   },
 };

--- a/packages/hardhat-web3/test/.eslintrc.js
+++ b/packages/hardhat-web3/test/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["../.eslintrc.js"],
+  extends: [`${__dirname}/../.eslintrc.js`],
   rules: {
     "import/no-extraneous-dependencies": [
       "error",


### PR DESCRIPTION
This PR changes how we define paths in our eslint config files, using absolute paths instead.

The reason I'm submitting it is that my editor was complaining that it was imposible to load the eslint config for `hardhat-core/test`. I fixed it according to the message it shown (which seemed to make sense), and `yarn lint` stopped working.

[This section of their documentation](https://eslint.org/docs/user-guide/configuring/configuration-files#relative-glob-patterns) seems to indicate that using `--config` changes how relative paths are interpreted, so my guess is that webstorm uses that, as our npm scripts don't use it.

To avoid this confusion, I used node.js' `__dirname` to declare everything with absolute paths instead.