### PR TITLE
Implement ReadOnlyValidEIP1559Transaction

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/transaction.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/transaction.ts
@@ -11,7 +11,7 @@ export const rpcTransaction = t.type(
     blockNumber: nullable(rpcQuantity),
     from: rpcAddress,
     gas: rpcQuantity,
-    gasPrice: rpcQuantity,
+    gasPrice: rpcQuantity, // NOTE: Its meaning was changed by EIP-1559
     hash: rpcHash,
     input: rpcData,
     nonce: rpcQuantity,
@@ -27,6 +27,10 @@ export const rpcTransaction = t.type(
     type: optional(rpcQuantity),
     chainId: optional(nullable(rpcQuantity)),
     accessList: optional(rpcAccessList),
+
+    // EIP-1559 properties
+    maxFeePerGas: optional(rpcQuantity),
+    maxPriorityFeePerGas: optional(rpcQuantity),
   },
   "RpcTransaction"
 );

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -3,6 +3,7 @@ import Common from "@ethereumjs/common";
 import { TypedTransaction } from "@ethereumjs/tx";
 import { Address, BN } from "ethereumjs-util";
 
+import { FeeMarketEIP1559TxData } from "@ethereumjs/tx/dist/types";
 import { RpcBlockWithTransactions } from "../../../core/jsonrpc/types/output/block";
 import { RpcTransactionReceipt } from "../../../core/jsonrpc/types/output/receipt";
 import { RpcTransaction } from "../../../core/jsonrpc/types/output/transaction";
@@ -21,6 +22,7 @@ import { ReadOnlyValidEIP2930Transaction } from "../transactions/ReadOnlyValidEI
 import { ReadOnlyValidTransaction } from "../transactions/ReadOnlyValidTransaction";
 import { HardhatBlockchainInterface } from "../types/HardhatBlockchainInterface";
 
+import { ReadOnlyValidEIP1559Transaction } from "../transactions/ReadOnlyValidEIP1559Transaction";
 import { rpcToBlockData } from "./rpcToBlockData";
 import { rpcToTxData } from "./rpcToTxData";
 
@@ -303,8 +305,10 @@ export class ForkBlockchain implements HardhatBlockchainInterface {
           rpcToTxData(transaction)
         );
       } else if (transaction.type.eqn(2)) {
-        // TODO(London): Implement ReadOnlyValidEIP1559Transaction
-        throw new Error("Not implemented");
+        tx = new ReadOnlyValidEIP1559Transaction(
+          new Address(transaction.from),
+          rpcToTxData(transaction) as FeeMarketEIP1559TxData
+        );
       } else {
         throw new InternalError(`Unknown transaction type ${transaction.type}`);
       }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToBlockData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToBlockData.ts
@@ -22,6 +22,7 @@ export function rpcToBlockData(rpcBlock: RpcBlockWithTransactions): BlockData {
       extraData: rpcBlock.extraData,
       mixHash: rpcBlock.mixHash,
       nonce: rpcBlock.nonce,
+      baseFeePerGas: rpcBlock.baseFeePerGas,
     },
     transactions: rpcBlock.transactions.map(rpcToTxData),
     // uncleHeaders are not fetched and set here as provider methods for getting them are not supported

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
@@ -6,14 +6,13 @@ import { RpcTransaction } from "../../../core/jsonrpc/types/output/transaction";
 export function rpcToTxData(
   rpcTransaction: RpcTransaction
 ): TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData {
+  const isEip1559 = rpcTransaction.type?.eqn(2) ?? false;
+
   return {
     gasLimit: rpcTransaction.gas,
     // NOTE: RPC EIP-1559 txs still have this field for backwards compatibility,
     //  but FeeMarketEIP1559TxData doesn't.
-    gasPrice:
-      rpcTransaction.type?.eqn(2) ?? false
-        ? undefined
-        : rpcTransaction.gasPrice,
+    gasPrice: isEip1559 ? undefined : rpcTransaction.gasPrice,
     to: rpcTransaction.to ?? undefined,
     nonce: rpcTransaction.nonce,
     data: rpcTransaction.input,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
@@ -1,13 +1,19 @@
 import { AccessListEIP2930TxData, TxData } from "@ethereumjs/tx";
 
+import { FeeMarketEIP1559TxData } from "@ethereumjs/tx/dist/types";
 import { RpcTransaction } from "../../../core/jsonrpc/types/output/transaction";
 
 export function rpcToTxData(
   rpcTransaction: RpcTransaction
-): TxData | AccessListEIP2930TxData {
-  const txData: AccessListEIP2930TxData = {
+): TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData {
+  return {
     gasLimit: rpcTransaction.gas,
-    gasPrice: rpcTransaction.gasPrice,
+    // NOTE: RPC EIP-1559 txs still have this field for backwards compatibility,
+    //  but FeeMarketEIP1559TxData doesn't.
+    gasPrice:
+      rpcTransaction.type?.eqn(2) ?? false
+        ? undefined
+        : rpcTransaction.gasPrice,
     to: rpcTransaction.to ?? undefined,
     nonce: rpcTransaction.nonce,
     data: rpcTransaction.input,
@@ -15,20 +21,13 @@ export function rpcToTxData(
     r: rpcTransaction.r,
     s: rpcTransaction.s,
     value: rpcTransaction.value,
-  };
-
-  if (rpcTransaction.type !== undefined) {
-    txData.type = rpcTransaction.type;
-  }
-  if (rpcTransaction.chainId !== undefined && rpcTransaction.chainId !== null) {
-    txData.chainId = rpcTransaction.chainId;
-  }
-  if (rpcTransaction.accessList !== undefined) {
-    txData.accessList = rpcTransaction.accessList.map((item) => [
+    type: rpcTransaction.type,
+    chainId: rpcTransaction.chainId ?? undefined,
+    maxFeePerGas: rpcTransaction.maxFeePerGas,
+    maxPriorityFeePerGas: rpcTransaction.maxPriorityFeePerGas,
+    accessList: rpcTransaction.accessList?.map((item) => [
       item.address,
       item.storageKeys ?? [],
-    ]);
-  }
-
-  return txData;
+    ]),
+  };
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/transactions/ReadOnlyValidEIP1559Transaction.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/transactions/ReadOnlyValidEIP1559Transaction.ts
@@ -11,8 +11,7 @@ import { InternalError } from "../../../core/providers/errors";
 /* eslint-disable @nomiclabs/only-hardhat-error */
 
 /**
- * This class is like `ReadOnlyValidTransaction` but for
- * EIP-2930 (access list) transactions.
+ * This class is like `ReadOnlyValidTransaction` but for EIP-1559 transactions.
  */
 export class ReadOnlyValidEIP1559Transaction extends FeeMarketEIP1559Transaction {
   public static fromTxData(
@@ -62,7 +61,7 @@ export class ReadOnlyValidEIP1559Transaction extends FeeMarketEIP1559Transaction
     });
 
     // this class should only be used with txs in a hardfork that
-    // supports EIP-2930
+    // supports EIP-1559
     (fakeCommon as any).isActivatedEIP = (eip: number) => {
       if (eip === 2930) {
         return true;
@@ -77,8 +76,8 @@ export class ReadOnlyValidEIP1559Transaction extends FeeMarketEIP1559Transaction
       );
     };
 
-    // this class should only be used with EIP-2930 txs,
-    // which (we assume) always have a defined `chainId` value
+    // this class should only be used with EIP-1559 txs,
+    // which always have a `chainId` value
     (fakeCommon as any).chainIdBN = () => {
       if (data.chainId !== undefined) {
         return new BN(data.chainId);

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/transactions/ReadOnlyValidEIP1559Transaction.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/transactions/ReadOnlyValidEIP1559Transaction.ts
@@ -1,0 +1,159 @@
+import Common from "@ethereumjs/common";
+import { FeeMarketEIP1559Transaction, TxOptions } from "@ethereumjs/tx";
+import { Address, BN } from "ethereumjs-util";
+
+import {
+  FeeMarketEIP1559TxData,
+  FeeMarketEIP1559ValuesArray,
+} from "@ethereumjs/tx/src/types";
+import { InternalError } from "../../../core/providers/errors";
+
+/* eslint-disable @nomiclabs/only-hardhat-error */
+
+/**
+ * This class is like `ReadOnlyValidTransaction` but for
+ * EIP-2930 (access list) transactions.
+ */
+export class ReadOnlyValidEIP1559Transaction extends FeeMarketEIP1559Transaction {
+  public static fromTxData(
+    _txData: FeeMarketEIP1559TxData,
+    _opts?: TxOptions
+  ): never {
+    throw new InternalError(
+      "`fromTxData` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public static fromSerializedTx(
+    _serialized: Buffer,
+    _opts?: TxOptions
+  ): never {
+    throw new InternalError(
+      "`fromSerializedTx` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public static fromRlpSerializedTx(
+    _serialized: Buffer,
+    _opts?: TxOptions
+  ): never {
+    throw new InternalError(
+      "`fromRlpSerializedTx` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public static fromValuesArray(
+    _values: FeeMarketEIP1559ValuesArray,
+    _opts?: TxOptions
+  ): never {
+    throw new InternalError(
+      "`fromRlpSerializedTx` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public readonly common: Common;
+
+  private readonly _sender: Address;
+
+  constructor(sender: Address, data: FeeMarketEIP1559TxData = {}) {
+    const fakeCommon = new Common({
+      chain: "mainnet",
+      hardfork: "london",
+    });
+
+    // this class should only be used with txs in a hardfork that
+    // supports EIP-2930
+    (fakeCommon as any).isActivatedEIP = (eip: number) => {
+      if (eip === 2930) {
+        return true;
+      }
+
+      if (eip === 1559) {
+        return true;
+      }
+
+      throw new Error(
+        "Expected `isActivatedEIP` to only be called with 2930 or 1559"
+      );
+    };
+
+    // this class should only be used with EIP-2930 txs,
+    // which (we assume) always have a defined `chainId` value
+    (fakeCommon as any).chainIdBN = () => {
+      if (data.chainId !== undefined) {
+        return new BN(data.chainId);
+      }
+
+      throw new Error("Expected txData to have a chainId");
+    };
+
+    super(data, { freeze: false, common: fakeCommon });
+
+    this.common = fakeCommon;
+    this._sender = sender;
+  }
+
+  public verifySignature(): boolean {
+    return true;
+  }
+
+  public getSenderAddress(): Address {
+    return this._sender;
+  }
+
+  public sign(): never {
+    throw new InternalError(
+      "`sign` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getDataFee(): never {
+    throw new InternalError(
+      "`getDataFee` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getBaseFee(): never {
+    throw new InternalError(
+      "`getBaseFee` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getUpfrontCost(): never {
+    throw new InternalError(
+      "`getUpfrontCost` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public validate(stringError?: false): never;
+  public validate(stringError: true): never;
+  public validate(_stringError: boolean = false): never {
+    throw new InternalError(
+      "`validate` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public toCreationAddress(): never {
+    throw new InternalError(
+      "`toCreationAddress` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getSenderPublicKey(): never {
+    throw new InternalError(
+      "`getSenderPublicKey` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getMessageToVerifySignature(): never {
+    throw new InternalError(
+      "`getMessageToVerifySignature` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+
+  public getMessageToSign(): never {
+    throw new InternalError(
+      "`getMessageToSign` is not implemented in ReadOnlyValidEIP1559Transaction"
+    );
+  }
+}

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -607,6 +607,12 @@ describe("HardhatNode", () => {
         blockToRun: 9812365, // this block has a EIP-2930 tx
         chainId: 3,
       },
+      {
+        networkName: "ropsten",
+        url: ALCHEMY_URL.replace("mainnet", "ropsten"),
+        blockToRun: 10499406, // this block has a EIP-1559 tx
+        chainId: 3,
+      },
     ];
 
     for (const { url, blockToRun, networkName, chainId } of forkedBlocks) {


### PR DESCRIPTION
This PR implements the EIP-1559 version of the transaction class that we use to read remote txs when forking.

This completes most of the forking functionality changes required for London.