### PR TITLE
Use `ethers.getSigner` instead of `ethers.provider.getSigner`

### DIFF
--- a/docs/guides/mainnet-forking.md
+++ b/docs/guides/mainnet-forking.md
@@ -87,7 +87,7 @@ await hre.network.provider.request({
 If you are using [`hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers), call `getSigner` after impersonating the account:
 
 ```
-const signer = await ethers.provider.getSigner("0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6")
+const signer = await ethers.getSigner("0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6")
 signer.sendTransaction(...)
 ```
 


### PR DESCRIPTION
This bit a user because `ethers.provider.getSigner` doesn't return a `SignerWithAddress`.