### PR TITLE
Adapt `eth_estimateGas` and `eth_call` to London

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
@@ -1163,15 +1163,14 @@ export class EthModule {
       data: rpcCall.data !== undefined ? rpcCall.data : toBuffer([]),
       gasLimit:
         rpcCall.gas !== undefined ? rpcCall.gas : this._node.getBlockGasLimit(),
-      gasPrice:
-        rpcCall.gasPrice !== undefined
-          ? rpcCall.gasPrice
-          : await this._node.getGasPrice(),
       value: rpcCall.value !== undefined ? rpcCall.value : new BN(0),
       accessList:
         rpcCall.accessList !== undefined
           ? this._rpcAccessListToNodeAccessList(rpcCall.accessList)
           : undefined,
+      gasPrice: rpcCall.gasPrice,
+      maxFeePerGas: rpcCall.maxFeePerGas,
+      maxPriorityFeePerGas: rpcCall.maxPriorityFeePerGas,
     };
   }
 
@@ -1601,7 +1600,7 @@ You can use them by running Hardhat Network with 'hardfork' ${ACCESS_LIST_MIN_HA
       rpcRequest.maxFeePerGas !== undefined
     ) {
       throw new InvalidInputError(
-        "Transaction cannot have both gasPrice and maxFeePerGas"
+        "Cannot send both gasPrice and maxFeePerGas params"
       );
     }
 
@@ -1610,7 +1609,7 @@ You can use them by running Hardhat Network with 'hardfork' ${ACCESS_LIST_MIN_HA
       rpcRequest.maxPriorityFeePerGas !== undefined
     ) {
       throw new InvalidInputError(
-        "Transaction cannot have both gasPrice and maxPriorityFeePerGas"
+        "Cannot send both gasPrice and maxPriorityFeePerGas"
       );
     }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -59,12 +59,15 @@ export interface CallParams {
   to?: Buffer;
   from: Buffer;
   gasLimit: BN;
-  gasPrice: BN;
   value: BN;
   data: Buffer;
   // We use this access list format because @ethereumjs/tx access list data
   // forces us to use it or stringify them
   accessList?: AccessListBufferItem[];
+  // Fee params
+  gasPrice?: BN;
+  maxFeePerGas?: BN;
+  maxPriorityFeePerGas?: BN;
 }
 
 export type TransactionParams =

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -2141,11 +2141,8 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     if (maxPriorityFeePerGas === undefined) {
       maxPriorityFeePerGas = await this.getMaxPriorityFeePerGas();
 
-      if (
-        callParams.maxFeePerGas !== undefined &&
-        callParams.maxFeePerGas.lt(maxPriorityFeePerGas)
-      ) {
-        maxPriorityFeePerGas = callParams.maxFeePerGas;
+      if (maxFeePerGas !== undefined && maxFeePerGas.lt(maxPriorityFeePerGas)) {
+        maxPriorityFeePerGas = maxFeePerGas;
       }
     }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -472,14 +472,38 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     call: CallParams,
     blockNumberOrPending: BN | "pending"
   ): Promise<RunCallResult> {
-    const tx = await this._getFakeTransaction({
-      ...call,
-      nonce: await this._getNonce(new Address(call.from), blockNumberOrPending),
-    });
+    let txParams: TransactionParams;
+
+    const nonce = await this._getNonce(
+      new Address(call.from),
+      blockNumberOrPending
+    );
+
+    if (call.gasPrice !== undefined || !this.isEip1559Active()) {
+      txParams = {
+        gasPrice: new BN(0),
+        nonce,
+        ...call,
+      };
+    } else {
+      const maxFeePerGas =
+        call.maxFeePerGas ?? call.maxPriorityFeePerGas ?? new BN(0);
+      const maxPriorityFeePerGas = call.maxPriorityFeePerGas ?? new BN(0);
+
+      txParams = {
+        ...call,
+        nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        accessList: call.accessList ?? [],
+      };
+    }
+
+    const tx = await this._getFakeTransaction(txParams);
 
     const result = await this._runInBlockContext(
       blockNumberOrPending,
-      async () => this._runTxAndRevertMutations(tx, blockNumberOrPending)
+      async () => this._runTxAndRevertMutations(tx, blockNumberOrPending, true)
     );
 
     const traces = await this._gatherTraces(result.execResult);
@@ -568,13 +592,77 @@ Hardhat Network's forking functionality only works with blocks from at least spu
   ): Promise<EstimateGasResult> {
     // We get the CallParams and transform it into a TransactionParams to be
     // able to run it.
-    const txParams = {
-      ...callParams,
-      nonce: await this._getNonce(
-        new Address(callParams.from),
-        blockNumberOrPending
-      ),
-    };
+    const nonce = await this._getNonce(
+      new Address(callParams.from),
+      blockNumberOrPending
+    );
+
+    // TODO: This is more complex in Geth, we should make sure we aren't missing
+    //  anything here.
+
+    let gasPrice = callParams.gasPrice;
+    let maxFeePerGas = callParams.maxFeePerGas;
+    let maxPriorityFeePerGas = callParams.maxPriorityFeePerGas;
+
+    if (!this.isEip1559Active()) {
+      if (gasPrice === undefined) {
+        gasPrice = await this.getGasPrice();
+      }
+    } else if (gasPrice === undefined) {
+      if (maxPriorityFeePerGas === undefined) {
+        maxPriorityFeePerGas = await this.getMaxPriorityFeePerGas();
+
+        if (
+          callParams.maxFeePerGas !== undefined &&
+          callParams.maxFeePerGas.lt(maxPriorityFeePerGas)
+        ) {
+          maxPriorityFeePerGas = callParams.maxFeePerGas;
+        }
+      }
+
+      if (callParams.maxPriorityFeePerGas === undefined) {
+        if (blockNumberOrPending !== "pending") {
+          const block = await this.getBlockByNumber(blockNumberOrPending);
+
+          maxFeePerGas = maxPriorityFeePerGas.add(
+            block?.header.baseFeePerGas ?? new BN(0)
+          );
+        }
+
+        const baseFeePerGas = await this.getNextBlockBaseFeePerGas();
+        maxFeePerGas = baseFeePerGas!.muln(2).add(maxPriorityFeePerGas);
+      }
+    }
+
+    let txParams: TransactionParams;
+
+    if (gasPrice !== undefined) {
+      if (callParams.accessList === undefined) {
+        // Legacy tx
+        txParams = {
+          ...callParams,
+          nonce,
+          gasPrice,
+        };
+      } else {
+        // Access list tx
+        txParams = {
+          ...callParams,
+          nonce,
+          gasPrice,
+          accessList: callParams.accessList ?? [],
+        };
+      }
+    } else {
+      // EIP-1559 tx
+      txParams = {
+        ...callParams,
+        nonce,
+        maxFeePerGas: maxFeePerGas!,
+        maxPriorityFeePerGas: maxPriorityFeePerGas!,
+        accessList: callParams.accessList ?? [],
+      };
+    }
 
     const tx = await this._getFakeTransaction(txParams);
 
@@ -1311,7 +1399,6 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       );
     }
 
-    // TODO(London): Test these validations.
     // Validate that maxFeePerGas >= next block's baseFee
     const nextBlockGasFee = await this.getNextBlockBaseFeePerGas();
     if (nextBlockGasFee !== undefined) {
@@ -1429,13 +1516,13 @@ Hardhat Network's forking functionality only works with blocks from at least spu
   > {
     const sender = new Address(txParams.from);
 
-    if ("maxFeePerGas" in txParams) {
+    if ("maxFeePerGas" in txParams && txParams.maxFeePerGas !== undefined) {
       return new FakeSenderEIP1559Transaction(sender, txParams, {
         common: this._vm._common,
       });
     }
 
-    if ("accessList" in txParams) {
+    if ("accessList" in txParams && txParams.accessList !== undefined) {
       return new FakeSenderAccessListEIP2930Transaction(sender, txParams, {
         common: this._vm._common,
       });
@@ -1909,7 +1996,8 @@ Hardhat Network's forking functionality only works with blocks from at least spu
    */
   private async _runTxAndRevertMutations(
     tx: TypedTransaction,
-    blockNumberOrPending: BN | "pending"
+    blockNumberOrPending: BN | "pending",
+    forceBaseFeeZero = false
   ): Promise<EVMResult> {
     const initialStateRoot = await this._stateManager.getStateRoot();
 
@@ -1922,32 +2010,41 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       } else {
         // We know that this block number exists, because otherwise
         // there would be an error in the RPC layer.
-        let block = await this.getBlockByNumber(blockNumberOrPending);
+        const block = await this.getBlockByNumber(blockNumberOrPending);
         assertHardhatInvariant(
           block !== undefined,
           "Tried to run a tx in the context of a non-existent block"
         );
 
-        // NOTE: This is a workaround of both an @ethereumjs/vm limitation, and
-        //   a bug in Hardhat Network.
-        //
-        // See: https://github.com/nomiclabs/hardhat/issues/1666
-        //
-        // If this VM is running with EIP1559 activated, and the block is not
-        // an EIP1559 one, this will crash, so we create a new one that has
-        // baseFeePerGas = 0.
-        if (
-          this.isEip1559Active() &&
-          block.header.baseFeePerGas === undefined
-        ) {
-          block = Block.fromBlockData(block, { freeze: false });
-          (block.header as any).baseFeePerGas = new BN(0);
-        }
-
         blockContext = block;
 
         // we don't need to add the tx to the block because runTx doesn't
         // know anything about the txs in the current block
+      }
+
+      // NOTE: This is a workaround of both an @ethereumjs/vm limitation, and
+      //   a bug in Hardhat Network.
+      //
+      // See: https://github.com/nomiclabs/hardhat/issues/1666
+      //
+      // If this VM is running with EIP1559 activated, and the block is not
+      // an EIP1559 one, this will crash, so we create a new one that has
+      // baseFeePerGas = 0.
+      //
+      // We also have an option to force the base fee to be zero,
+      // we don't want to debit any balance nor fail any tx when running an
+      // eth_call. This will make the BASEFEE option also return 0, which
+      // shouldn't. See: https://github.com/nomiclabs/hardhat/issues/1688
+      if (
+        this.isEip1559Active() &&
+        (blockContext.header.baseFeePerGas === undefined || forceBaseFeeZero)
+      ) {
+        blockContext = Block.fromBlockData(blockContext, {
+          freeze: false,
+          common: this._vm._common,
+        });
+
+        (blockContext.header as any).baseFeePerGas = new BN(0);
       }
 
       return await this._vm.runTx({

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -355,7 +355,7 @@ describe("Eth module - hardfork dependant tests", function () {
     });
 
     describe("Call and estimate gas types validation by hardfork", function () {
-      describe("Without access list", function () {
+      describe("Running a hardfork without access list", function () {
         useProviderAndCommon("petersburg");
 
         it("Should reject an eth_call if an access list was provided", async function () {
@@ -369,6 +369,17 @@ describe("Eth module - hardfork dependant tests", function () {
           );
         });
 
+        it("Should reject an eth_call with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await assertInvalidArgumentsError(
+            this.provider,
+            "eth_call",
+            [{ from: sender, to: sender, maxFeePerGas: "0x1" }],
+            "EIP-1559 style fee params (maxFeePerGas or maxPriorityFeePerGas) received but they are not supported by the current hardfork"
+          );
+        });
+
         it("Should reject an eth_estimateGas if an access list was provided", async function () {
           const [sender] = await this.provider.send("eth_accounts");
 
@@ -376,9 +387,17 @@ describe("Eth module - hardfork dependant tests", function () {
             { from: sender, to: sender, accessList: [] },
           ]);
         });
+
+        it("Should reject an eth_estimateGas with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await assertInvalidArgumentsError(this.provider, "eth_estimateGas", [
+            { from: sender, to: sender, maxFeePerGas: numberToRpcQuantity(1) },
+          ]);
+        });
       });
 
-      describe("With access list", function () {
+      describe("Running a hardfork without access list", function () {
         useProviderAndCommon("berlin");
 
         it("Should accept an eth_call if an access list was provided", async function () {
@@ -389,11 +408,50 @@ describe("Eth module - hardfork dependant tests", function () {
           ]);
         });
 
+        it("Should reject an eth_call with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await assertInvalidArgumentsError(
+            this.provider,
+            "eth_call",
+            [{ from: sender, to: sender, maxFeePerGas: "0x1" }],
+            "EIP-1559 style fee params (maxFeePerGas or maxPriorityFeePerGas) received but they are not supported by the current hardfork"
+          );
+        });
+
         it("Should accept an eth_estimateGas if an access list was provided", async function () {
           const [sender] = await this.provider.send("eth_accounts");
 
           await this.provider.send("eth_estimateGas", [
             { from: sender, to: sender, accessList: [] },
+          ]);
+        });
+
+        it("Should reject an eth_estimateGas with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await assertInvalidArgumentsError(this.provider, "eth_estimateGas", [
+            { from: sender, to: sender, maxFeePerGas: numberToRpcQuantity(1) },
+          ]);
+        });
+      });
+
+      describe("Running a hardfork with EIP-1559", function () {
+        useProviderAndCommon("london");
+
+        it("Should accept an eth_call with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await this.provider.send("eth_call", [
+            { from: sender, to: sender, maxFeePerGas: "0x1" },
+          ]);
+        });
+
+        it("Should reject an eth_estimateGas with EIP-1559 fields", async function () {
+          const [sender] = await this.provider.send("eth_accounts");
+
+          await this.provider.send("eth_estimateGas", [
+            { from: sender, to: sender, maxFeePerGas: numberToRpcQuantity(1) },
           ]);
         });
       });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -431,7 +431,11 @@ describe("Eth module - hardfork dependant tests", function () {
           const [sender] = await this.provider.send("eth_accounts");
 
           await assertInvalidArgumentsError(this.provider, "eth_estimateGas", [
-            { from: sender, to: sender, maxFeePerGas: numberToRpcQuantity(1) },
+            {
+              from: sender,
+              to: sender,
+              maxFeePerGas: numberToRpcQuantity(10e9),
+            },
           ]);
         });
       });
@@ -447,11 +451,15 @@ describe("Eth module - hardfork dependant tests", function () {
           ]);
         });
 
-        it("Should reject an eth_estimateGas with EIP-1559 fields", async function () {
+        it("Should accept an eth_estimateGas with EIP-1559 fields", async function () {
           const [sender] = await this.provider.send("eth_accounts");
 
           await this.provider.send("eth_estimateGas", [
-            { from: sender, to: sender, maxFeePerGas: numberToRpcQuantity(1) },
+            {
+              from: sender,
+              to: sender,
+              maxFeePerGas: numberToRpcQuantity(10e9),
+            },
           ]);
         });
       });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
@@ -559,13 +559,13 @@ contract C {
                   from: CALLER,
                   to: contractAddress,
                   data: balanceSelector,
-                  gasLimit: numberToRpcQuantity(gasLimit),
+                  gas: numberToRpcQuantity(gasLimit),
                   gasPrice: numberToRpcQuantity(gasPrice),
                 },
               ]);
 
               assert.isTrue(
-                rpcDataToBN(balanceResult).lt(
+                rpcDataToBN(balanceResult).eq(
                   ethBalance.subn(gasLimit * gasPrice)
                 )
               );
@@ -663,13 +663,13 @@ contract C {
                   to: contractAddress,
                   data: balanceSelector,
                   maxPriorityFeePerGas: numberToRpcQuantity(3),
-                  gasLimit: 500_000,
+                  gas: numberToRpcQuantity(500_000),
                 },
               ]);
 
               // The miner will get the priority fee
               assert.isTrue(
-                rpcDataToBN(balanceResult).lt(ethBalance.subn(500_000 * 3))
+                rpcDataToBN(balanceResult).eq(ethBalance.subn(500_000 * 3))
               );
             });
 
@@ -680,13 +680,13 @@ contract C {
                   to: contractAddress,
                   data: balanceSelector,
                   gasPrice: numberToRpcQuantity(6),
-                  gasLimit: 500_000,
+                  gas: numberToRpcQuantity(500_000),
                 },
               ]);
 
               // The miner will get the gasPrice * gas as a normalized priority fee
               assert.isTrue(
-                rpcDataToBN(balanceResult).lt(ethBalance.subn(500_000 * 6))
+                rpcDataToBN(balanceResult).eq(ethBalance.subn(500_000 * 6))
               );
             });
           });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 
+import { BN } from "ethereumjs-util";
 import {
   numberToRpcQuantity,
   rpcDataToNumber,
@@ -24,6 +25,11 @@ import {
   deployContract,
   sendTxToZeroAddress,
 } from "../../../../helpers/transactions";
+import { compileLiteral } from "../../../../stack-traces/compilation";
+import {
+  rpcDataToBN,
+  rpcQuantityToBN,
+} from "../../../../../../../src/internal/core/jsonrpc/types/base-types";
 
 describe("Eth module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
@@ -486,6 +492,203 @@ describe("Eth module", function () {
               [account, blockNumber]
             );
             assert.equal(initialBalanceAfterTx, "0xde0b6b3a7640000");
+          });
+        });
+
+        describe("Fee price fields", function () {
+          let deploymentBytecode: string;
+          let balanceSelector: string;
+
+          before(async function () {
+            const [_, compilerOutput] = await compileLiteral(`
+contract C {
+  function balance() public view returns (uint) {
+    return msg.sender.balance;
+  }
+}
+`);
+            const contract = compilerOutput.contracts["literal.sol"].C;
+            deploymentBytecode = `0x${contract.evm.bytecode.object}`;
+            balanceSelector = `0x${contract.evm.methodIdentifiers["balance()"]}`;
+          });
+
+          const CALLER = DEFAULT_ACCOUNTS_ADDRESSES[2];
+          let contractAddress: string;
+          let ethBalance: BN;
+
+          function deployContractAndGetEthBalance() {
+            beforeEach(async function () {
+              contractAddress = await deployContract(
+                this.provider,
+                deploymentBytecode
+              );
+
+              ethBalance = rpcQuantityToBN(
+                await this.provider.send("eth_getBalance", [CALLER])
+              );
+              assert.notEqual(ethBalance.toString(), "0");
+            });
+          }
+
+          describe("When running without EIP-1559", function () {
+            useProvider({ hardfork: "berlin" });
+
+            deployContractAndGetEthBalance();
+
+            it("Should default to gasPrice 0", async function () {
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                },
+              ]);
+
+              assert.equal(
+                rpcDataToBN(balanceResult).toString(),
+                ethBalance.toString()
+              );
+            });
+
+            it("Should use any provided gasPrice", async function () {
+              const gasLimit = 200_000;
+              const gasPrice = 2;
+
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                  gasLimit: numberToRpcQuantity(gasLimit),
+                  gasPrice: numberToRpcQuantity(gasPrice),
+                },
+              ]);
+
+              assert.isTrue(
+                rpcDataToBN(balanceResult).lt(
+                  ethBalance.subn(gasLimit * gasPrice)
+                )
+              );
+            });
+          });
+
+          describe("When running with EIP-1559", function () {
+            useProvider({ hardfork: "london" });
+
+            deployContractAndGetEthBalance();
+
+            it("Should validate that gasPrice and maxFeePerGas & maxPriorityFeePerGas are not mixed", async function () {
+              await assertInvalidInputError(
+                this.provider,
+                "eth_call",
+                [
+                  {
+                    from: CALLER,
+                    to: contractAddress,
+                    gasPrice: numberToRpcQuantity(1),
+                    maxFeePerGas: numberToRpcQuantity(1),
+                  },
+                ],
+                "Cannot send both gasPrice and maxFeePerGas"
+              );
+
+              await assertInvalidInputError(
+                this.provider,
+                "eth_call",
+                [
+                  {
+                    from: CALLER,
+                    to: contractAddress,
+                    gasPrice: numberToRpcQuantity(1),
+                    maxPriorityFeePerGas: numberToRpcQuantity(1),
+                  },
+                ],
+                "Cannot send both gasPrice and maxPriorityFeePerGas"
+              );
+            });
+
+            it("Should validate that maxFeePerGas >= maxPriorityFeePerGas", async function () {
+              await assertInvalidInputError(
+                this.provider,
+                "eth_call",
+                [
+                  {
+                    from: CALLER,
+                    to: contractAddress,
+                    maxFeePerGas: numberToRpcQuantity(1),
+                    maxPriorityFeePerGas: numberToRpcQuantity(2),
+                  },
+                ],
+                "maxPriorityFeePerGas (2) is bigger than maxFeePerGas (1)"
+              );
+            });
+
+            it("Should default to maxFeePerGas = 0 if nothing provided", async function () {
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                },
+              ]);
+
+              assert.equal(
+                rpcDataToBN(balanceResult).toString(),
+                ethBalance.toString()
+              );
+            });
+
+            it("Should use maxFeePerGas if provided with a maxPriorityFeePerGas = 0", async function () {
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                  maxFeePerGas: numberToRpcQuantity(1),
+                },
+              ]);
+
+              // This doesn't change because the baseFeePerGas of block where we
+              // run the eth_call is 0
+              assert.equal(
+                rpcDataToBN(balanceResult).toString(),
+                ethBalance.toString()
+              );
+            });
+
+            it("Should use maxPriorityFeePerGas if provided, with maxFeePerGas = maxPriorityFeePerGas", async function () {
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                  maxPriorityFeePerGas: numberToRpcQuantity(3),
+                  gasLimit: 500_000,
+                },
+              ]);
+
+              // The miner will get the priority fee
+              assert.isTrue(
+                rpcDataToBN(balanceResult).lt(ethBalance.subn(500_000 * 3))
+              );
+            });
+
+            it("Should use gasPrice if provided", async function () {
+              const balanceResult = await this.provider.send("eth_call", [
+                {
+                  from: CALLER,
+                  to: contractAddress,
+                  data: balanceSelector,
+                  gasPrice: numberToRpcQuantity(6),
+                  gasLimit: 500_000,
+                },
+              ]);
+
+              // The miner will get the gasPrice * gas as a normalized priority fee
+              assert.isTrue(
+                rpcDataToBN(balanceResult).lt(ethBalance.subn(500_000 * 6))
+              );
+            });
           });
         });
       });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
@@ -1,6 +1,12 @@
 import { assert } from "chai";
 import { BN, toBuffer, zeroAddress } from "ethereumjs-util";
 
+import sinon, { SinonSpy } from "sinon";
+import {
+  AccessListEIP2930Transaction,
+  FeeMarketEIP1559Transaction,
+  Transaction,
+} from "@ethereumjs/tx";
 import { numberToRpcQuantity } from "../../../../../../../internal/core/jsonrpc/types/base-types";
 import { workaroundWindowsCiFailures } from "../../../../../../utils/workaround-windows-ci-failures";
 import { assertInvalidInputError } from "../../../../helpers/assertions";
@@ -12,6 +18,9 @@ import {
 } from "../../../../helpers/providers";
 import { retrieveForkBlockNumber } from "../../../../helpers/retrieveForkBlockNumber";
 import { deployContract } from "../../../../helpers/transactions";
+import { HardhatNode } from "../../../../../../../src/internal/hardhat-network/provider/node";
+import { RpcBlockOutput } from "../../../../../../../src/internal/hardhat-network/provider/output";
+import { rpcQuantityToBN } from "../../../../../../../src/internal/core/jsonrpc/types/base-types";
 
 describe("Eth module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
@@ -205,6 +214,163 @@ describe("Eth module", function () {
                 ],
                 "maxPriorityFeePerGas (2) is bigger than maxFeePerGas (1)"
               );
+            });
+
+            describe("Default values", function () {
+              const ONE_GWEI = new BN(10).pow(new BN(9));
+              // TODO: We test an internal method here. We should improve this.
+              // Note: We don't need to test incompatible values (e.g. gasPrice and maxFeePerGas).
+
+              let spy: SinonSpy;
+
+              beforeEach(function () {
+                spy = sinon.spy(
+                  HardhatNode.prototype as any,
+                  "_runTxAndRevertMutations"
+                );
+              });
+
+              afterEach(function () {
+                spy.restore();
+              });
+
+              it("Should use a gasPrice if provided", async function () {
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    gasPrice: numberToRpcQuantity(ONE_GWEI.muln(10)),
+                  },
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("gasPrice" in firstArg);
+
+                const tx: Transaction | AccessListEIP2930Transaction = firstArg;
+                assert.isTrue(tx.gasPrice.eq(ONE_GWEI.muln(10)));
+              });
+
+              it("Should use the maxFeePerGas and maxPriorityFeePerGas if provided", async function () {
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxFeePerGas: numberToRpcQuantity(ONE_GWEI.muln(10)),
+                    maxPriorityFeePerGas: numberToRpcQuantity(ONE_GWEI.muln(5)),
+                  },
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("maxFeePerGas" in firstArg);
+
+                const tx: FeeMarketEIP1559Transaction = firstArg;
+                assert.isTrue(tx.maxFeePerGas.eq(ONE_GWEI.muln(10)));
+                assert.isTrue(tx.maxPriorityFeePerGas.eq(ONE_GWEI.muln(5)));
+              });
+
+              it("should use the default maxPriorityFeePerGas, 1gwei", async function () {
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxFeePerGas: numberToRpcQuantity(ONE_GWEI.muln(10)),
+                  },
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("maxFeePerGas" in firstArg);
+
+                const tx: FeeMarketEIP1559Transaction = firstArg;
+                assert.isTrue(tx.maxFeePerGas.eq(ONE_GWEI.muln(10)));
+                assert.isTrue(tx.maxPriorityFeePerGas.eq(ONE_GWEI));
+              });
+
+              it("should cap the maxPriorityFeePerGas with maxFeePerGas", async function () {
+                await this.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+                  "0x0",
+                ]);
+
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxFeePerGas: numberToRpcQuantity(123),
+                  },
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("maxFeePerGas" in firstArg);
+
+                const tx: FeeMarketEIP1559Transaction = firstArg;
+                assert.isTrue(tx.maxFeePerGas.eqn(123));
+                assert.isTrue(tx.maxPriorityFeePerGas.eqn(123));
+              });
+
+              it("should use twice the next block's base fee as default maxFeePerGas, plus the priority fee, when the blocktag is pending", async function () {
+                await this.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+                  numberToRpcQuantity(10),
+                ]);
+
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxPriorityFeePerGas: numberToRpcQuantity(1),
+                  },
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("maxFeePerGas" in firstArg);
+
+                const tx: FeeMarketEIP1559Transaction = firstArg;
+                assert.isTrue(tx.maxFeePerGas.eqn(21));
+                assert.isTrue(tx.maxPriorityFeePerGas.eqn(1));
+              });
+
+              it("should use the block's base fee per gas as maxFeePerGas, plus the priority fee, when estimating in a past block", async function () {
+                const block: RpcBlockOutput = await this.provider.send(
+                  "eth_getBlockByNumber",
+                  ["latest", false]
+                );
+
+                await this.provider.send("eth_estimateGas", [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxPriorityFeePerGas: numberToRpcQuantity(1),
+                  },
+                  "latest",
+                ]);
+
+                const call = spy.getCall(0);
+                assert.isDefined(call);
+
+                const firstArg = call.firstArg;
+                assert.isTrue("maxFeePerGas" in firstArg);
+
+                const tx: FeeMarketEIP1559Transaction = firstArg;
+                assert.isTrue(
+                  tx.maxFeePerGas.eq(
+                    rpcQuantityToBN(block.baseFeePerGas!).addn(1)
+                  )
+                );
+                assert.isTrue(tx.maxPriorityFeePerGas.eqn(1));
+              });
             });
           });
         });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
@@ -158,6 +158,56 @@ describe("Eth module", function () {
           // We know that it should fit in 100k gas
           assert.isTrue(new BN(toBuffer(estimation)).lten(100000));
         });
+
+        describe("Fee price fields", function () {
+          describe("Running a hardfork with EIP-1559", function () {
+            it("Should validate that gasPrice and maxFeePerGas & maxPriorityFeePerGas are not mixed", async function () {
+              await assertInvalidInputError(
+                this.provider,
+                "eth_estimateGas",
+                [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    gasPrice: numberToRpcQuantity(1),
+                    maxFeePerGas: numberToRpcQuantity(1),
+                  },
+                ],
+                "Cannot send both gasPrice and maxFeePerGas"
+              );
+
+              await assertInvalidInputError(
+                this.provider,
+                "eth_estimateGas",
+                [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    gasPrice: numberToRpcQuantity(1),
+                    maxPriorityFeePerGas: numberToRpcQuantity(1),
+                  },
+                ],
+                "Cannot send both gasPrice and maxPriorityFeePerGas"
+              );
+            });
+
+            it("Should validate that maxFeePerGas >= maxPriorityFeePerGas", async function () {
+              await assertInvalidInputError(
+                this.provider,
+                "eth_estimateGas",
+                [
+                  {
+                    from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                    to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+                    maxFeePerGas: numberToRpcQuantity(1),
+                    maxPriorityFeePerGas: numberToRpcQuantity(2),
+                  },
+                ],
+                "maxPriorityFeePerGas (2) is bigger than maxFeePerGas (1)"
+              );
+            });
+          });
+        });
       });
     });
   });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendRawTransaction.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendRawTransaction.ts
@@ -127,7 +127,13 @@ describe("Eth module", function () {
         });
 
         describe("Base fee validation", function () {
-          // We set an initial base fee too high for the fixture txs
+          // The raw tx we are using may not work in a fork because of its
+          // chainID and nonce
+          if (isFork) {
+            return;
+          }
+
+          // We set an initial base fee too high for the raw tx
           useProvider({ initialBaseFeePerGas: 100e9 });
 
           describe("With automining enabled", function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendTransaction.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendTransaction.ts
@@ -135,7 +135,7 @@ describe("Eth module", function () {
                 maxFeePerGas: numberToRpcQuantity(10),
                 maxPriorityFeePerGas: numberToRpcQuantity(10),
               },
-              "Transaction cannot have both gasPrice and maxFeePerGas",
+              "Cannot send both gasPrice and maxFeePerGas",
               InvalidInputError.CODE
             );
           });
@@ -151,7 +151,7 @@ describe("Eth module", function () {
                 gasPrice: numberToRpcQuantity(10),
                 maxFeePerGas: numberToRpcQuantity(10),
               },
-              "Transaction cannot have both gasPrice and maxFeePerGas",
+              "Cannot send both gasPrice and maxFeePerGas",
               InvalidInputError.CODE
             );
           });
@@ -167,7 +167,7 @@ describe("Eth module", function () {
                 gasPrice: numberToRpcQuantity(1),
                 maxPriorityFeePerGas: numberToRpcQuantity(1),
               },
-              "Transaction cannot have both gasPrice and maxPriorityFeePerGas",
+              "Cannot send both gasPrice and maxPriorityFeePerGas",
               InvalidInputError.CODE
             );
           });


### PR DESCRIPTION
This PR turned out to be more challenging than expected.

The reason for this are that:

(1) `eth_call` should run an EVM Message that doesn't pay gas unless the user specifies it. EIP-1559 makes this more complex, as you can't just set the gas price to 0, because of the baseFeePerGas. To workaround this we create a new block with base fee 0 when we run an `eth_call`, but that will break BASEFEE (see: #1688).

(2) The default `maxFeePerGas` and `maxPriorityFeePerGas` in `eth_estimateGas` can be tricky to compute, specially when it's in an older block. I'm not sure how to test this yet.

On the plus side, this PR also fixes #1436.

fixes #1601
fixes #1602