### PR TITLE
README.md updates

### DIFF
--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -8,8 +8,6 @@ Developed by [Nomic Labs](https://nomiclabs.io/) and funded by an Ethereum Found
 
 Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay up to date on new releases, plugins and tutorials.
 
-🚧 **You are looking at the development branch of Hardhat. For the currently released versions of Hardhat and its plugins take a look at this repository's tags.** 🚧
-
 ## Installation
 
 To install Hardhat, go to an empty folder, initialize an `npm` project (i.e. `npm init`), and run

--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -1,4 +1,4 @@
-![](https://user-images.githubusercontent.com/176499/96893278-ebc67580-1460-11eb-9530-d5df3a3d65d0.png) [![NPM Package](https://img.shields.io/npm/v/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/hardhat) ![Build Status](https://github.com/nomiclabs/hardhat/workflows/CI/badge.svg)
+![](https://user-images.githubusercontent.com/176499/96893278-ebc67580-1460-11eb-9530-d5df3a3d65d0.png) [![NPM Package](https://img.shields.io/npm/v/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/hardhat)
 
 ---
 


### PR DESCRIPTION
This PR makes two small changes to the main README.md file:

1. Remove the CI badge, as it doesn't make sense any more, with our current CI setup.
2. Remove the warning about this being the development version, as that was accidentally pushed to [`npm`](https://www.npmjs.com/package/hardhat) on most releases, which is confusing.