### PR TITLE
Use `npx hardhat init` as an intialization workflow

### DIFF
--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -88,7 +88,18 @@ async function main() {
     if (
       hardhatArguments.config === undefined &&
       !isCwdInsideProject() &&
-      process.stdout.isTTY === true
+      // Windows terminal emulators are not actually TTYs, so `stdout.isTTY`
+      // can be false. There are a few emulators that workaround this by setting
+      // aliases to the most common commands, and shims/wraps them with winpty.
+      //
+      // For more information, read this: https://github.com/nodejs/node/issues/3006
+      //
+      // As we don't have a reliable way to detect if we are on a TTY on Windows,
+      // and given that somehow many users think that `npx hardhat init` is a
+      // thing, we can use it to detect their intention to initialize the
+      // project and don't fail if stdout is not a TTY.
+      (process.stdout.isTTY === true ||
+        process.argv[process.argv.length - 1] === "init")
     ) {
       await createProject();
       return;

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -51,6 +51,8 @@ export const ERRORS = {
       title: "You are not inside a Hardhat project",
       description: `You are trying to run Hardhat outside of a Hardhat project.
 
+Try running: npx hardhat init
+
 You can learn how to use Hardhat by reading the [Getting Started guide](../getting-started).`,
       shouldBeReported: false,
     },


### PR DESCRIPTION
This is an attempt at fixing #1408. Please read the comments in the diff to learn how it works.