### PR TITLE
improvements and possible logic break

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -333,7 +333,7 @@ abstract class SenderProvider extends ProviderWrapper {
     return this._wrappedProvider.request(args);
   }
 
-  protected abstract async _getSender(): Promise<string | undefined>;
+  protected abstract _getSender(): Promise<string | undefined>;
 }
 
 export class AutomaticSenderProvider extends SenderProvider {

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
@@ -82,7 +82,7 @@ export class JsonRpcServer implements IJsonRpcServer {
           }
 
           log("JSON-RPC server closed");
-          resolve();
+          resolve("Promise successfully resolved");
         });
       }),
       new Promise((resolve, reject) => {
@@ -95,7 +95,7 @@ export class JsonRpcServer implements IJsonRpcServer {
           }
 
           log("Websocket server closed");
-          resolve();
+          resolve("Promise successfully resolved");
         });
       }),
     ]);


### PR DESCRIPTION
Note: ````account.ts````

````
'async' modifier cannot be used with 'abstract' modifier.ts(1243)
````
[async](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/internal/core/providers/accounts.ts#:~:text=protected%20abstract%20async%20_getSender()%3A%20Promise%3Cstring%20%7C%20undefined%3E%3B)

Fix:
````
protected abstract _getSender(): Promise<string | undefined>;
````

Note: ````account.ts````

Possible logic break related to ````gasPrice: undefined``` is because of:

````
export interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
  /**
   * The transaction's gas price.
   */
  gasPrice?: never
  /**
   * The maximum inclusion fee per gas (this fee is given to the miner)
   */
  maxPriorityFeePerGas?: BNLike
  /**
   * The maximum total fee
   */
  maxFeePerGas?: BNLike
}
````
[FeeMarketEIP1559TxData  EthereumJS tx](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/types.ts)

Fix:

Update ````gasPrice?: never```` to ````gasPrice?: never | BNLike````

See Pull Request for EthereumJS: https://github.com/ethereumjs/ethereumjs-monorepo/pull/1385



Note in ````server.ts````

````
Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?ts(2794)
lib.es2015.promise.d.ts(33, 34): An argument for 'value' was not provided.
````
[server.ts](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts)

FIX:
````
 resolve("Promise is successfully resolved");

