### PR TITLE
docs: list hardhat-packager in plugins list

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -374,6 +374,14 @@ const plugins = [
     description: "Allows changing the current network in Hardhat.",
     tags: ["Testing"],
   },
+  {
+    name: "hardhat-packager",
+    author: "Paul Razvan Berg",
+    authorUrl: "https://github.com/paulrberg",
+    url: "https://github.com/paulrberg/hardhat-packager",
+    description: "Prepare the contract artifacts and the TypeChain bindings for registry deployment.",
+    tags: ["Deployment", "Tasks", "TypeChain"],
+  },
 ];
 
 module.exports = plugins.map((p) => ({

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -379,7 +379,8 @@ const plugins = [
     author: "Paul Razvan Berg",
     authorUrl: "https://github.com/paulrberg",
     url: "https://github.com/paulrberg/hardhat-packager",
-    description: "Prepare the contract artifacts and the TypeChain bindings for registry deployment.",
+    description:
+      "Prepare the contract artifacts and the TypeChain bindings for registry deployment.",
     tags: ["Deployment", "Tasks", "TypeChain"],
   },
 ];

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -378,7 +378,7 @@ const plugins = [
     name: "hardhat-packager",
     author: "Paul Razvan Berg",
     authorUrl: "https://github.com/paulrberg",
-    url: "https://github.com/paulrberg/hardhat-packager",
+    url: "https://github.com/paulrberg/hardhat-packager/tree/main",
     description:
       "Prepare the contract artifacts and the TypeChain bindings for registry deployment.",
     tags: ["Deployment", "Tasks", "TypeChain"],


### PR DESCRIPTION
- [x] This PR includes a **documentation change**, so its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.

---

My first Hardhat plugin 😊

https://github.com/paulrberg/hardhat-packager