### PR TITLE
docs: update info about @typechain/hardhat plugin

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -164,12 +164,12 @@ const plugins = [
     tags: ["explorer", "debugging", "development-tool"],
   },
   {
-    name: "hardhat-typechain",
-    author: "Rahul Sethuram",
-    authorUrl: "https://twitter.com/rhlsthrm",
-    url: "https://github.com/rhlsthrm/hardhat-typechain/tree/master",
-    description: "Generate TypeChain type definitions for smart contracts.",
-    tags: ["Testing", "Tasks"],
+    name: "@typechain/hardhat",
+    author: "Kris Kaczor",
+    authorUrl: "https://github.com/krzkaczor",
+    url: "https://github.com/ethereum-ts/TypeChain/tree/master/packages/hardhat",
+    description: "Automatically generate TypeScript bindings for smart contracts.",
+    tags: ["Tasks", "Testing", "TypeChain"],
   },
   {
     name: "hardhat-spdx-license-identifier",

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -167,8 +167,10 @@ const plugins = [
     name: "@typechain/hardhat",
     author: "Kris Kaczor",
     authorUrl: "https://github.com/krzkaczor",
-    url: "https://github.com/ethereum-ts/TypeChain/tree/master/packages/hardhat",
-    description: "Automatically generate TypeScript bindings for smart contracts.",
+    url:
+      "https://github.com/ethereum-ts/TypeChain/tree/master/packages/hardhat",
+    description:
+      "Automatically generate TypeScript bindings for smart contracts.",
     tags: ["Tasks", "Testing", "TypeChain"],
   },
   {


### PR DESCRIPTION
- [x] This PR includes a **documentation change**, so its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.

---

The [@typechain/hardhat](https://github.com/ethereum-ts/TypeChain/tree/master/packages/hardhat) package supersedes [hardhat-typechain](https://duckduckgo.com/?q=hardhat-typechain&ia=web).