### PR TITLE
Require ethers from hardhat explicitly

### DIFF
--- a/docs/tutorial/testing-contracts.md
+++ b/docs/tutorial/testing-contracts.md
@@ -10,6 +10,7 @@ Let's start with the code below. We'll explain it next, but for now paste this i
 
 ```js
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 describe("Token contract", function () {
   it("Deployment should assign the total supply of tokens to the owner", async function () {
@@ -44,12 +45,6 @@ const [owner] = await ethers.getSigners();
 ```
 
 A `Signer` in ethers.js is an object that represents an Ethereum account. It's used to send transactions to contracts and other accounts. Here we're getting a list of the accounts in the node we're connected to, which in this case is **Hardhat Network**, and only keeping the first one.
-
-The `ethers` variable is available in the global scope. If you like your code always being explicit, you can add this line at the top:
-
-```js
-const { ethers } = require("hardhat");
-```
 
 ::: tip
 
@@ -91,6 +86,7 @@ If you need to send a transaction from an account (or `Signer` in ethers.js spea
 
 ```js{18}
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 describe("Transactions", function () {
   it("Should transfer tokens between accounts", async function () {
@@ -116,8 +112,9 @@ describe("Transactions", function () {
 Now that we've covered the basics you'll need for testing your contracts, here's a full test suite for the token with a lot of additional information about Mocha and how to structure your tests. We recommend reading through.
 
 ```js
-// We import Chai to use its asserting functions here.
+// We import Chai to use its asserting functions here, and ethers to use its Signers.
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 // `describe` is a Mocha function that allows you to organize your tests. It's
 // not actually needed, but having your tests organized makes debugging them

--- a/docs/tutorial/testing-contracts.md
+++ b/docs/tutorial/testing-contracts.md
@@ -84,7 +84,7 @@ To do this we're using [Chai](https://www.chaijs.com/) which is an assertions li
 
 If you need to send a transaction from an account (or `Signer` in ethers.js speak) other than the default one to test your code, you can use the `connect()` method in your ethers.js `Contract` to connect it to a different account. Like this:
 
-```js{18}
+```js{17}
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 


### PR DESCRIPTION
- [x] This PR includes a **documentation change**, so its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.

Require ethers from hardhat explicitly. There are configurations of common tools (VSCode for example) where editor automatically finds and adds require from "ethers" and not from "hardhat" (ethers gets installed into the project earlier in the tutorial), which often leads beginners to unexpected errors.