### PR TITLE
Drop support for Node.js 10

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -25,12 +25,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-core on Windows with Node 10
+    name: Test hardhat-core on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -43,12 +43,12 @@ jobs:
         run: yarn test:except-tracing
 
   test_on_macos:
-    name: Test hardhat-core on MacOS with Node 10
+    name: Test hardhat-core on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-ethers-ci.yml
+++ b/.github/workflows/hardhat-ethers-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-ethers on Windows with Node 10
+    name: Test hardhat-ethers on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-ethers on MacOS with Node 10
+    name: Test hardhat-ethers on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-etherscan-ci.yml
+++ b/.github/workflows/hardhat-etherscan-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-etherscan on Windows with Node 10
+    name: Test hardhat-etherscan on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-etherscan on MacOS with Node 10
+    name: Test hardhat-etherscan on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-ganache-ci.yml
+++ b/.github/workflows/hardhat-ganache-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-ganache on Windows with Node 10
+    name: Test hardhat-ganache on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-ganache on MacOS with Node 10
+    name: Test hardhat-ganache on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-network-forking-ci.yml
+++ b/.github/workflows/hardhat-network-forking-ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile

--- a/.github/workflows/hardhat-network-tracing-ci.yml
+++ b/.github/workflows/hardhat-network-tracing-ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-shorthand-ci.yml
+++ b/.github/workflows/hardhat-shorthand-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-shorthand on Windows with Node 10
+    name: Test hardhat-shorthand on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-shorthand on MacOS with Node 10
+    name: Test hardhat-shorthand on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-solhint-ci.yml
+++ b/.github/workflows/hardhat-solhint-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-solhint on Windows with Node 10
+    name: Test hardhat-solhint on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-solhint on MacOS with Node 10
+    name: Test hardhat-solhint on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-solpp-ci.yml
+++ b/.github/workflows/hardhat-solpp-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_macos:
-    name: Test hardhat-solpp on MacOS with Node 10
+    name: Test hardhat-solpp on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-truffle4-ci.yml
+++ b/.github/workflows/hardhat-truffle4-ci.yml
@@ -29,12 +29,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-truffle4 on Windows with Node 10
+    name: Test hardhat-truffle4 on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -44,12 +44,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-truffle4 on MacOS with Node 10
+    name: Test hardhat-truffle4 on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-truffle5-ci.yml
+++ b/.github/workflows/hardhat-truffle5-ci.yml
@@ -29,12 +29,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-truffle5 on Windows with Node 10
+    name: Test hardhat-truffle5 on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -44,12 +44,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-truffle5 on MacOS with Node 10
+    name: Test hardhat-truffle5 on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-vyper-ci.yml
+++ b/.github/workflows/hardhat-vyper-ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-waffle-ci.yml
+++ b/.github/workflows/hardhat-waffle-ci.yml
@@ -29,12 +29,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-waffle on Windows with Node 10
+    name: Test hardhat-waffle on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -44,12 +44,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-waffle on MacOS with Node 10
+    name: Test hardhat-waffle on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-web3-ci.yml
+++ b/.github/workflows/hardhat-web3-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-web3 on Windows with Node 10
+    name: Test hardhat-web3 on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-web3 on MacOS with Node 10
+    name: Test hardhat-web3 on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hardhat-web3-legacy-ci.yml
+++ b/.github/workflows/hardhat-web3-legacy-ci.yml
@@ -27,12 +27,12 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-web3-legacy on Windows with Node 10
+    name: Test hardhat-web3-legacy on Windows with Node 12
     runs-on: windows-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -42,12 +42,12 @@ jobs:
         run: yarn test
 
   test_on_macos:
-    name: Test hardhat-web3-legacy on MacOS with Node 10
+    name: Test hardhat-web3-legacy on MacOS with Node 12
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         run: yarn --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - uses: actions/checkout@v2
       - name: Install
         working-directory: docs

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -129,6 +129,7 @@ module.exports = {
           title: "Reference",
           collapsable: false,
           children: [
+            ["/reference/stability-guarantees.html", "Stability guarantees", 0],
             ["/reference/solidity-support.html", "Solidity support", 0],
           ],
         },

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -24,6 +24,7 @@ https://www.usehardhat.com/* https://hardhat.org/:splat 301!
 /console-log /hardhat-network/#console-log 302
 /discord https://discord.gg/TETZs2KK4k 302
 /hre /advanced/hardhat-runtime-environment.html 302
+/nodejs-versions /reference/stability-guarantees.html 302
 
 ## Hardhat migration
 

--- a/docs/reference/stability-guarantees.md
+++ b/docs/reference/stability-guarantees.md
@@ -1,0 +1,26 @@
+# Stability guarantees
+
+Hardhat doesn't follow semver strictly, but it still aims to be a stable and easy-to-use platform, and we won't introduce breaking changes without notice. Instead, we may introduce breaking changes in some minor versions.
+
+Those breaking changes are part of these categories:
+
+- Dropping support for unmaintained Node.js versions
+- Changing the default config of Hardhat Network
+
+## Hardhat Network default config
+
+Hardhat Network should closely resemble Ethereum Mainnet by default. Given that Ethereum does introduce breaking changes in the form of hardforks or network upgrades, we need to do the same with its default config. For example, we would eventually change the default `hardfork` config field in the network `hardhat`.
+
+We will only introduce these changes when a hardfork activates on Mainnet. This will be introduced in a minor version that changes the default `hardfork`, but will also modify other fields, like `blockGasLimit`, to match those of Mainnet.
+
+## Node.js versions support
+
+Hardhat supports every currently maintained Node.js version, up to two months after its end-of-life. After that period of time, we will stop testing against it, and print a warning when trying to use it. These actions will lead to a new minor version being released.
+
+We recommend running Hardhat using the current LTS Node.js version. You can learn about it [here](https://nodejs.org/en/about/releases/).
+
+## How to avoid the breaking changes introduced by Hardhat
+
+In general, there's no need to avoid them. Using Hardhat with any actively maintained Node.js version means that you'd be running with defaults that closely resemble Ethereum Mainnet.
+
+If you want to play extra-safe, and make sure your project will continue running years down the road using the same Node.js version, please, install Hardhat using a [tilde range](https://docs.npmjs.com/cli/v7/using-npm/semver#tilde-ranges-123-12-1).

--- a/docs/reference/stability-guarantees.md
+++ b/docs/reference/stability-guarantees.md
@@ -4,8 +4,8 @@ Hardhat doesn't follow semver strictly, but it still aims to be a stable and eas
 
 Those breaking changes are part of these categories:
 
-- Dropping support for unmaintained Node.js versions
 - Changing the default config of Hardhat Network
+- Dropping support for unmaintained Node.js versions
 
 ## Hardhat Network default config
 
@@ -23,4 +23,4 @@ We recommend running Hardhat using the current LTS Node.js version. You can lear
 
 In general, there's no need to avoid them. Using Hardhat with any actively maintained Node.js version means that you'd be running with defaults that closely resemble Ethereum Mainnet.
 
-If you want to play extra-safe, and make sure your project will continue running years down the road using the same Node.js version, please, install Hardhat using a [tilde range](https://docs.npmjs.com/cli/v7/using-npm/semver#tilde-ranges-123-12-1).
+If you want to play extra-safe, and make sure your project will continue running years down the road using the same Node.js version, please install Hardhat using a [tilde range](https://docs.npmjs.com/cli/v7/using-npm/semver#tilde-ranges-123-12-1).

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -23,7 +23,7 @@
     "hardhat": "internal/cli/cli.js"
   },
   "engines": {
-    "node": ">=8.2.0"
+    "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
   },
   "scripts": {
     "lint": "yarn prettier --check && yarn eslint",

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -38,12 +38,18 @@ async function printVersionMessage(packageJson: PackageJson) {
   console.log(packageJson.version);
 }
 
-function ensureValidNodeVersion(packageJson: PackageJson) {
+function printWarningAboutNodeJsVersionIfNeceesary(packageJson: PackageJson) {
   const requirement = packageJson.engines.node;
   if (!semver.satisfies(process.version, requirement)) {
-    throw new HardhatError(ERRORS.GENERAL.INVALID_NODE_VERSION, {
-      requirement,
-    });
+    console.warn(
+      chalk.yellow(
+        `You are using an version of Node.js that is not supported by Hardhat, and it may work incorrectly, or not work at all.
+
+Please, upgrade your Node.js version.
+
+To learn more about which versions of Node.js are supported go to https://hardhat.org/nodejs-versions`
+      )
+    );
   }
 }
 
@@ -55,7 +61,7 @@ async function main() {
   try {
     const packageJson = await getPackageJson();
 
-    ensureValidNodeVersion(packageJson);
+    printWarningAboutNodeJsVersionIfNeceesary(packageJson);
 
     const envVariableArguments = getEnvHardhatArguments(
       HARDHAT_PARAM_DEFINITIONS,

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -43,7 +43,7 @@ function printWarningAboutNodeJsVersionIfNeceesary(packageJson: PackageJson) {
   if (!semver.satisfies(process.version, requirement)) {
     console.warn(
       chalk.yellow(
-        `You are using an version of Node.js that is not supported by Hardhat, and it may work incorrectly, or not work at all.
+        `You are using a version of Node.js that is not supported by Hardhat, and it may work incorrectly, or not work at all.
 
 Please, upgrade your Node.js version.
 


### PR DESCRIPTION
This PR drops support for Node.js 10. This means that we stop running that version on our CI, and that we print a warning if you use it.

It also adds documentation about our stability guarantees, and links it in the warning mentioned above.