### PR TITLE
Add code address to trace

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
@@ -46,6 +46,7 @@ export interface CreateMessageTrace extends BaseEvmMessageTrace {
 export interface CallMessageTrace extends BaseEvmMessageTrace {
   calldata: Buffer;
   address: Buffer;
+  codeAddress: Buffer;
 }
 
 export interface DecodedCreateMessageTrace extends CreateMessageTrace {

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
@@ -120,10 +120,7 @@ export class VMTracer {
 
           trace = precompileTrace;
         } else {
-          const codeAddress =
-            message._codeAddress !== undefined
-              ? message._codeAddress
-              : message.to;
+          const codeAddress = message.codeAddress;
 
           const code = await this._getContractCode(codeAddress);
 
@@ -137,7 +134,7 @@ export class VMTracer {
             numberOfSubtraces: 0,
             depth: message.depth,
             gasUsed: DUMMY_GAS_USED,
-            codeAddress: message.codeAddress.toBuffer()
+            codeAddress: codeAddress.toBuffer()
           };
 
           trace = callTrace;

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
@@ -137,6 +137,7 @@ export class VMTracer {
             numberOfSubtraces: 0,
             depth: message.depth,
             gasUsed: DUMMY_GAS_USED,
+            codeAddress: message.codeAddress.toBuffer()
           };
 
           trace = callTrace;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] This PR includes a **new feature**, so the change was previously discussed on an Issue or with someone from the team.

---

This PR adds the `codeAddress` property to the Hardhat trace. For CALLCODE & DELEGATECALL it's set to the address of the code that is executed, for others CALL opcodes, it's set to `message.to` (set [here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/ae96604a7e384f3d7fc4005f6489aaca1717cc2e/packages/vm/src/evm/eei.ts#L507) in ethereumjs)

This logic was duplicated in Hardhat, the PR replaces it with the ethereumjs helper (https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/src/evm/message.ts#L35)

Also discussed this change in #1772.

I couldn't figure out how to add unit testing but I would be happy to do so with some help on that!