### PR TITLE
hardhat-etherscan: add optimism support

### DIFF
--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -252,10 +252,10 @@ Possible causes are:
     // type. We don't want that type to always contain the `ovm` field, because users only using hardhat-etherscan
     // without the Optimism plugin should not have that field in their type definitions
     const configCopy = ({ ...config } as unknown) as {
-      ovm: { solcVersion: string };
+      ovm?: { solcVersion: string };
     };
-    const ovmSolcVersion = configCopy?.ovm?.solcVersion;
-    if (!ovmSolcVersion) {
+    const ovmSolcVersion = configCopy.ovm?.solcVersion;
+    if (ovmSolcVersion === undefined) {
       const message = `It looks like you are verifying an OVM contract, but do not have an OVM solcVersion specified in the hardhat config.`;
       throw new NomicLabsHardhatPluginError(pluginName, message);
     }

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -252,7 +252,7 @@ Possible causes are:
     // type. We don't want that type to always contain the `ovm` field, because users only using hardhat-etherscan
     // without the Optimism plugin should not have that field in their type definitions
     const configCopy = ({ ...config } as unknown) as {
-      ovm?: { solcVersion: string };
+      ovm?: { solcVersion?: string };
     };
     const ovmSolcVersion = configCopy.ovm?.solcVersion;
     if (ovmSolcVersion === undefined) {

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -80,11 +80,11 @@ const networkIDtoEndpoints: NetworkMap = {
     browserURL: "https://ftmscan.com",
   },
   [NetworkID.OPTIMISTIC_ETHEREUM]: {
-    apiURL: "https://api-optimistic.etherscan.io",
+    apiURL: "https://api-optimistic.etherscan.io/api",
     browserURL: "https://optimistic.etherscan.io/",
   },
   [NetworkID.OPTIMISTIC_KOVAN]: {
-    apiURL: "https://api-kovan-optimistic.etherscan.io",
+    apiURL: "https://api-kovan-optimistic.etherscan.io/api",
     browserURL: "https://kovan-optimistic.etherscan.io/",
   },
   [NetworkID.POLYGON]: {

--- a/packages/hardhat-etherscan/src/solc/bytecode.ts
+++ b/packages/hardhat-etherscan/src/solc/bytecode.ts
@@ -165,7 +165,9 @@ export async function extractMatchingContractInformation(
 
   // If this is OVM bytecode, do the required find and replace (see above comments for more info)
   if (deployedBytecode.isOvmInferred()) {
-    runtimeBytecodeSymbols.object.split(ovmFindOpcodes).join(ovmReplaceOpcodes);
+    runtimeBytecodeSymbols.object = runtimeBytecodeSymbols.object
+      .split(ovmFindOpcodes)
+      .join(ovmReplaceOpcodes);
   }
 
   const analyzedBytecode = await compareBytecode(

--- a/packages/hardhat-etherscan/src/solc/bytecode.ts
+++ b/packages/hardhat-etherscan/src/solc/bytecode.ts
@@ -47,9 +47,22 @@ interface BytecodeSlice {
 
 type NestedSliceReferences = BytecodeSlice[][];
 
+// If the compiler output bytecode is OVM bytecode, we need to make a fix to account for a bug in some versions of
+// the OVM compiler. The artifact’s deployedBytecode is incorrect, but because its bytecode (initcode) is correct, when we
+// actually deploy contracts, the code that ends up getting stored on chain is also correct. During verification,
+// Etherscan will compile the source code, pull out the artifact’s deployedBytecode, and then perform the
+// below find and replace, then check that resulting output against the code retrieved on chain from eth_getCode.
+// We define the strings for that find and replace here, and use them later so we can know if the bytecode matches
+// before it gets to Etherscan. Source: https://github.com/ethereum-optimism/optimism/blob/8d67991aba584c1703692ea46273ea8a1ef45f56/packages/contracts/src/contract-dumps.ts#L195-L204
+const ovmFindOpcodes =
+  "336000905af158601d01573d60011458600c01573d6000803e3d621234565260ea61109c52";
+const ovmReplaceOpcodes =
+  "336000905af158600e01573d6000803e3d6000fd5b3d6001141558600a015760016000f35b";
+
 export class Bytecode {
   private _bytecode: string;
   private _version: string;
+  private _isOvm: boolean;
 
   private _executableSection: BytecodeSlice;
   private _metadataSection: BytecodeSlice;
@@ -68,10 +81,27 @@ export class Bytecode {
       start: this._executableSection.length,
       length: metadataSectionSizeInBytes * 2,
     };
+
+    // Check if this is OVM bytecode by looking for the concatenation of the two opcodes defined here:
+    // https://github.com/ethereum-optimism/optimism/blob/33cb9025f5e463525d6abe67c8457f81a87c5a24/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol#L143
+    //   - This check would only fail if the EVM solidity compiler didn't use any of the following opcodes: https://github.com/ethereum-optimism/optimism/blob/c42fc0df2790a5319027393cb8fa34e4f7bb520f/packages/contracts/contracts/optimistic-ethereum/iOVM/execution/iOVM_ExecutionManager.sol#L94-L175
+    //     This is the list of opcodes that calls the OVM execution manager. But the current solidity
+    //     compiler seems to add REVERT in all cases, meaning it currently won't happen and this check
+    //     will always be correct.
+    //   - It is possible, though very unlikely, that this string appears in the bytecode of an EVM
+    //     contract. As a result result, this _isOvm flag should only be used after trying to infer
+    //     the solc version
+    //   - We need this check because OVM bytecode has no metadata, so when verifying
+    //     OVM bytecode the check in `inferSolcVersion` will always return `METADATA_ABSENT_VERSION_RANGE`.
+    this._isOvm = bytecode.includes(ovmReplaceOpcodes);
   }
 
   public getInferredSolcVersion(): string {
     return this._version;
+  }
+
+  public isOvmInferred(): boolean {
+    return this._isOvm;
   }
 
   public getExecutableSection(): string {
@@ -99,7 +129,11 @@ export async function lookupMatchingBytecode(
       continue;
     }
 
-    if (!matchingCompilerVersions.includes(buildInfo.solcVersion)) {
+    if (
+      !matchingCompilerVersions.includes(buildInfo.solcVersion) &&
+      // if OVM, we will not have matching compiler versions because we can't infer a specific OVM solc version from the bytecode
+      !deployedBytecode.isOvmInferred()
+    ) {
       continue;
     }
 
@@ -128,6 +162,11 @@ export async function extractMatchingContractInformation(
   const contract = buildInfo.output.contracts[sourceName][contractName];
   // Normalize deployed bytecode according to this contract.
   const { deployedBytecode: runtimeBytecodeSymbols } = contract.evm;
+
+  // If this is OVM bytecode, do the required find and replace (see above comments for more info)
+  if (deployedBytecode.isOvmInferred()) {
+    runtimeBytecodeSymbols.object.split(ovmFindOpcodes).join(ovmReplaceOpcodes);
+  }
 
   const analyzedBytecode = await compareBytecode(
     deployedBytecode,
@@ -160,7 +199,10 @@ export async function compareBytecode(
   );
 
   if (
-    deployedExecutableSection.length !== runtimeBytecodeExecutableSectionLength
+    deployedExecutableSection.length !==
+      runtimeBytecodeExecutableSectionLength &&
+    // OVM bytecode has no metadata so we ignore this comparison if operating on OVM bytecode
+    !deployedBytecode.isOvmInferred()
   ) {
     return null;
   }


### PR DESCRIPTION
Resolves #1730

Adds support for verifying contracts on Optimistic Ethereum (OVM). Notes:
- It seemed like a more work to access the provider's chainId everywhere that `isOvmInferred()` is used, so I went with the latter approach to keep the diff smaller and minimize the risk of breaking any exiting functionality.
- No test cases have been added, but this code was used to verify the Uniswap V3 contracts on Optimistic Ethereum. Sample verification [here](https://optimistic.etherscan.io/address/0x1F98431c8aD98523631AE4a59f267346ea31F984#code)
- Added lots of comments which should explain everything going on, but let me know if you have any questions

Thanks to @ben-chain and @K-Ho of Optimism for their help