### PR TITLE
docs: mention "london" among accepted values for "evmVersion"

### DIFF
--- a/docs/guides/compile-contracts.md
+++ b/docs/guides/compile-contracts.md
@@ -59,7 +59,7 @@ module.exports = {
 
 - `optimizer`: an object with `enabled` and `runs` keys. Default value: `{ enabled: false, runs: 200 }`.
 
-- `evmVersion`: a string controlling the target evm version. One of `homestead`, `tangerineWhistle`, `spuriousDragon`, `byzantium`, `constantinople`, `petersburg`, `istanbul`, and `berlin`. Default value: managed by `solc`.
+- `evmVersion`: a string controlling the target evm version. One of `homestead`, `tangerineWhistle`, `spuriousDragon`, `byzantium`, `constantinople`, `petersburg`, `istanbul`, `berlin` or `london`. Default value: managed by `solc`.
 
 If any of your contracts have a version pragma that is not satisfied by the compiler version you configured, then Hardhat will throw an error.
 

--- a/docs/guides/compile-contracts.md
+++ b/docs/guides/compile-contracts.md
@@ -59,7 +59,7 @@ module.exports = {
 
 - `optimizer`: an object with `enabled` and `runs` keys. Default value: `{ enabled: false, runs: 200 }`.
 
-- `evmVersion`: a string controlling the target evm version. One of `homestead`, `tangerineWhistle`, `spuriousDragon`, `byzantium`, `constantinople`, `petersburg`, `istanbul`, `berlin` or `london`. Default value: managed by `solc`.
+- `evmVersion`: a string controlling the target evm version. For example: `istanbul`, `berlin` or `london`. Default value: managed by `solc`.
 
 If any of your contracts have a version pragma that is not satisfied by the compiler version you configured, then Hardhat will throw an error.
 


### PR DESCRIPTION
- [x] This PR includes a **documentation change**, so its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.

---

Since [v2.6.0](https://github.com/nomiclabs/hardhat/releases/tag/hardhat-core-v2.6.0), Hardhat accepts "london" as one of the allowed values for `evmVersion`.