### PR TITLE
Subtle tweak to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,9 @@ Please:
  - DELETE the items that DON'T make sense for your PR.
 -->
 
-- [ ] This PR includes a **documentation change**, so its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
-- [ ] This PR includes a **bug fix**, so relevant tests have been included.
-- [ ] This PR includes a **new feature**, so the change was previously discussed on an Issue or with someone from the team.
+- [ ] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
+- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
+- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
 - [x] I didn't do anything of this.
 
 ---


### PR DESCRIPTION
I saw someone use the checklist, by deleting the unused ones and checking the box for a doc change, but they *did not* base it on the `website` branch.  That made me think that maybe they just saw the first part, "This PR includes a documentation change," and ignore the rest of the statement, so I thought it would be good to make this tweak.