### PR TITLE
Fix traceTransaction for FakeSender transactions

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -1235,20 +1235,50 @@ Hardhat Network's forking functionality only works with blocks from at least spu
         for (const tx of block.transactions) {
           let txWithCommon: TypedTransaction;
           if (tx.type === 0) {
-            txWithCommon = new Transaction(tx, {
-              common: vm._common,
-            });
-          } else if (tx.type === 1) {
-            txWithCommon = new AccessListEIP2930Transaction(tx, {
-              common: vm._common,
-            });
-          } else if (tx.type === 2) {
-            txWithCommon = new FeeMarketEIP1559Transaction(
-              { ...tx, gasPrice: undefined },
-              {
+            if (tx instanceof FakeSenderTransaction) {
+              txWithCommon = new FakeSenderTransaction(
+                tx.getSenderAddress(),
+                tx,
+                {
+                  common: vm._common,
+                }
+              );
+            } else {
+              txWithCommon = new Transaction(tx, {
                 common: vm._common,
-              }
-            );
+              });
+            }
+          } else if (tx.type === 1) {
+            if (tx instanceof FakeSenderAccessListEIP2930Transaction) {
+              txWithCommon = new FakeSenderAccessListEIP2930Transaction(
+                tx.getSenderAddress(),
+                tx,
+                {
+                  common: vm._common,
+                }
+              );
+            } else {
+              txWithCommon = new AccessListEIP2930Transaction(tx, {
+                common: vm._common,
+              });
+            }
+          } else if (tx.type === 2) {
+            if (tx instanceof FakeSenderEIP1559Transaction) {
+              txWithCommon = new FakeSenderEIP1559Transaction(
+                tx.getSenderAddress(),
+                { ...tx, gasPrice: undefined },
+                {
+                  common: vm._common,
+                }
+              );
+            } else {
+              txWithCommon = new FeeMarketEIP1559Transaction(
+                { ...tx, gasPrice: undefined },
+                {
+                  common: vm._common,
+                }
+              );
+            }
           } else {
             throw new InternalError(
               "Only legacy, EIP2930, and EIP1559 txs are supported"

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -66,6 +66,40 @@ describe("Debug module", function () {
           });
         });
 
+        it("Should return the right values for fake sender txs", async function () {
+          const impersonatedAddress =
+            "0xC014BA5EC014ba5ec014Ba5EC014ba5Ec014bA5E";
+
+          await this.provider.send("eth_sendTransaction", [
+            {
+              from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+              to: impersonatedAddress,
+              value: "0x100",
+            },
+          ]);
+
+          await this.provider.send("hardhat_impersonateAccount", [
+            impersonatedAddress,
+          ]);
+
+          const txHash = await this.provider.send("eth_sendTransaction", [
+            {
+              from: impersonatedAddress,
+              to: DEFAULT_ACCOUNTS_ADDRESSES[1],
+            },
+          ]);
+          const trace: RpcDebugTraceOutput = await this.provider.send(
+            "debug_traceTransaction",
+            [txHash]
+          );
+          assert.deepEqual(trace, {
+            gas: 21000,
+            failed: false,
+            returnValue: "",
+            structLogs: [],
+          });
+        });
+
         it("Should return the right values for successful contract tx", async function () {
           const contractAddress = await deployContract(
             this.provider,


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

This PR fixes `debug_traceTransaction` calls for FakeSender transactions. While tracing transactions of type FakeSender***Transaction, I made sure that they are not converted to normal Transaction types and we end up losing sender information.

Fixes #1799