### PR TITLE
Loosen ethereumjs hardforks check

### DIFF
--- a/packages/hardhat-core/test/internal/util/hardforks.ts
+++ b/packages/hardhat-core/test/internal/util/hardforks.ts
@@ -1,5 +1,4 @@
 import Common from "@ethereumjs/common";
-import { hardforks } from "@ethereumjs/common/dist/hardforks";
 import { assert } from "chai";
 import {
   getHardforkName,
@@ -16,12 +15,6 @@ describe("Hardfork utils", function () {
         assert.doesNotThrow(
           () => new Common({ chain: "mainnet", hardfork: name })
         );
-      }
-    });
-
-    it("Has all the hardforks that ethereumjs recognizes", function () {
-      for (const [hf, _] of hardforks) {
-        assert.include(Object.values(HardforkName), hf);
       }
     });
   });


### PR DESCRIPTION
This PR loosens an internal utils test that checks that all ethereumjs hardforks are supported by hardhat.

This was discovered in our (ethereumjs) hardhat e2e test when we added `shanghai` as a future hard fork placeholder to `@ethereumjs/common` and it failed on this test.

I am opening this PR to ensure that a patch release from `@ethereumjs/common` including a new hardfork doesn’t break the hardhat tests. This PR removes the check. I was going to rewrite it to:

```typescript
      for (const name of Object.values(HardforkName)) {
        assert.include(
          hardforks.map((h) => h[0]),
          name
        );
      }
```

but this is already covered by the prior test (`Only has hardforks that ethereumjs recognizes`)