### PR TITLE
Fully explain the benefit of chai.use

### DIFF
--- a/packages/hardhat-waffle/README.md
+++ b/packages/hardhat-waffle/README.md
@@ -67,6 +67,6 @@ const { waffle } = require("hardhat");
 const { deployContract } = waffle;
 ```
 
-Also, you don't need to call `chai.use`.
+Also, you don't need to call `chai.use` in order to use [Waffle's Chai matchers](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html).
 
 Note that by default, Hardhat saves its compilation output into `artifacts/` instead of `build/`. You can either use that directory in your tests, or [customize your Hardhat config](https://hardhat.org/config/#path-configuration).


### PR DESCRIPTION
Newbies won't immediately understand why `chai.use` is normally needed, therefore they also won't know why it's a benefit that `hardhat-waffle` takes care of this automatically.  So document it explicitly.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
