### PR TITLE
Fix typo on Mainnet forking docs

### DIFF
--- a/docs/hardhat-network/guides/mainnet-forking.md
+++ b/docs/hardhat-network/guides/mainnet-forking.md
@@ -18,7 +18,7 @@ You can also configure Hardhat Network to always do this:
 networks: {
   hardhat: {
     forking: {
-      url: "https://eth-mainnet.alchemyapi.io/v2/<key>";
+      url: "https://eth-mainnet.alchemyapi.io/v2/<key>",
     }
   }
 }


### PR DESCRIPTION
Should be a `,` instead of `;`