### PR TITLE
Replace no-return-await with @typescript-eslint/return-await

### DIFF
--- a/config/eslint/eslintrc.js
+++ b/config/eslint/eslintrc.js
@@ -152,9 +152,12 @@ module.exports = {
     "guard-for-in": "error",
     "id-blacklist": "error",
     "id-match": "error",
-    "import/no-extraneous-dependencies": ["error", {
-      devDependencies: false,
-    }],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: false,
+      },
+    ],
     "import/order": [
       "error",
       {
@@ -177,7 +180,8 @@ module.exports = {
     "no-extra-bind": "error",
     "no-new-func": "error",
     "no-new-wrappers": "error",
-    "no-return-await": "error",
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": "error",
     "no-sequences": "error",
     "no-sparse-arrays": "error",
     "no-template-curly-in-string": "error",

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -61,7 +61,7 @@ export class Artifacts implements IArtifacts {
         });
       }
 
-      return fsExtra.readJson(trueCaseArtifactPath);
+      return await fsExtra.readJson(trueCaseArtifactPath);
     } catch (error) {
       if (
         typeof error.message === "string" &&

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
@@ -29,7 +29,7 @@ export function getCurrentStack(): NodeJS.CallSite[] {
 }
 
 export async function wrapWithSolidityErrorsCorrection(
-  f: () => any,
+  f: () => Promise<any>,
   stackFramesToRemove: number
 ) {
   const stackTraceAtCall = getCurrentStack().slice(stackFramesToRemove);

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -167,7 +167,7 @@ export class CompilerDownloader {
 
     if (await this._versionExists(version, platform)) {
       try {
-        return this._getCompilerBuildByPlatform(version, platform);
+        return await this._getCompilerBuildByPlatform(version, platform);
       } catch (e) {
         log("Couldn't download native compiler, using solcjs instead");
       }

--- a/packages/hardhat-etherscan/src/solc/version.ts
+++ b/packages/hardhat-etherscan/src/solc/version.ts
@@ -41,7 +41,7 @@ export async function getVersions(): Promise<CompilersList> {
       );
     }
 
-    return response.json();
+    return await response.json();
   } catch (error) {
     throw new NomicLabsHardhatPluginError(
       pluginName,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

<!-- Add a description of your PR here -->

This PR sets no-return-await to "off" and sets @typescript-eslint/return-await to "error" in eslintrc config to enforce return await as requested in #1596 . It also fixes all linting errors that occur as a result of the change.
