### PR TITLE
hardhat-etherscan: add arbitrum support

### DIFF
--- a/.changeset/warm-adults-bake.md
+++ b/.changeset/warm-adults-bake.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+hardhat-etherscan: add support for [Arbitrum](https://github.com/OffchainLabs/arbitrum)

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -36,6 +36,8 @@ enum NetworkID {
   // Polygon
   POLYGON = 137,
   POLYGON_MUMBAI = 80001,
+  // Arbitrum
+  ARBITRUM_ONE = 42161,
 }
 
 const networkIDtoEndpoints: NetworkMap = {
@@ -95,6 +97,10 @@ const networkIDtoEndpoints: NetworkMap = {
     apiURL: "https://api-testnet.polygonscan.com/api",
     browserURL: "https://mumbai.polygonscan.com/",
   },
+  [NetworkID.ARBITRUM_ONE]: {
+    apiURL: "https://api.arbiscan.io/api",
+    browserURL: "https://arbiscan.io/",
+  }
 };
 
 export async function getEtherscanEndpoints(

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -100,7 +100,7 @@ const networkIDtoEndpoints: NetworkMap = {
   [NetworkID.ARBITRUM_ONE]: {
     apiURL: "https://api.arbiscan.io/api",
     browserURL: "https://arbiscan.io/",
-  }
+  },
 };
 
 export async function getEtherscanEndpoints(


### PR DESCRIPTION
This PR adds support for verifying smart contracts against [Arbiscan](https://twitter.com/etherscan/status/1432112087489257482)
