### PR TITLE
Fix eth_feeHistory computation

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -142,7 +142,7 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
   public static readonly EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE: number = 3;
 
   // See eth_feeHistory for an explanation of what this means
-  public static readonly EIP1559_REWARD_PERCENTILE: number = 0.5;
+  public static readonly EIP1559_REWARD_PERCENTILE: number = 50;
 
   private _nodeHasFeeHistory?: boolean;
   private _nodeSupportsEIP1559?: boolean;


### PR DESCRIPTION
The effective gas price was being used for computing the rewards. This is only valid when the base fee is 0.

This PR also uses 50 percentile instead of 0.5 for computing the gas price in the `AutomaticGasPriceProvider`.