### PR TITLE
fix hardhat node outputting ascii escape characters when redirecting to a file

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
@@ -35,15 +35,19 @@ function printLine(line: string) {
 }
 
 function replaceLastLine(newLine: string) {
-  process.stdout.write(
-    // eslint-disable-next-line prefer-template
-    ansiEscapes.cursorHide +
-      ansiEscapes.cursorPrevLine +
-      newLine +
-      ansiEscapes.eraseEndLine +
-      "\n" +
-      ansiEscapes.cursorShow
-  );
+  if (process.stdout.isTTY) {
+    process.stdout.write(
+      // eslint-disable-next-line prefer-template
+      ansiEscapes.cursorHide +
+        ansiEscapes.cursorPrevLine +
+        newLine +
+        ansiEscapes.eraseEndLine +
+        "\n" +
+        ansiEscapes.cursorShow
+    );
+  } else {
+    process.stdout.write(newLine+"\n");
+  }
 }
 
 /**

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
@@ -46,7 +46,7 @@ function replaceLastLine(newLine: string) {
         ansiEscapes.cursorShow
     );
   } else {
-    process.stdout.write(newLine+"\n");
+    process.stdout.write(newLine + "\n");
   }
 }
 


### PR DESCRIPTION


<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.


---

<!-- Add a description of your PR here -->
Implemented if statement proposed by fvictorio in issue #467 that omits the ascii escape characters when outputting to a file. Below I've attached 3 screenshots of: 
1. Reproducing the issue.
2. The solution resulting in the desired output.
3. Making sure that the new if statement's other case is working.


![screenshot1-problem](https://user-images.githubusercontent.com/49007921/131951464-70df8fe4-c222-4efe-a57e-3312e2c6d7ce.png)
![screenshot2-solution](https://user-images.githubusercontent.com/49007921/131951468-42f4949a-b832-4548-8e86-545ebf98491f.png)
![screenshot3-didnt-break-old-working-case](https://user-images.githubusercontent.com/49007921/131951469-e4e763a7-da3e-4b14-b298-34ca6cac30e4.png)
