### PR TITLE
Give Truffle recommendations consistent with existing deployment guide

### DIFF
--- a/docs/guides/truffle-migration.md
+++ b/docs/guides/truffle-migration.md
@@ -47,7 +47,9 @@ Once you've written your hardhat-truffle fixtures for your migrations and comple
 
 ### Deployment
 
-When it comes to deploying, there are no plugins that implement a deployment system for Hardhat yet, but there's [an open issue](https://github.com/nomiclabs/hardhat/issues/381) with some ideas and we'd value your opinion on how to best design it.
+When it comes to deploying, there are no official plugins that implement a deployment system for Hardhat yet, but there's [an open issue](https://github.com/nomiclabs/hardhat/issues/381) with some ideas and we'd value your opinion on how to best design it.
+
+In the meantime, we recommend [deploying your smart contracts using scripts](../guides/deploying.md), or using [the hardhat-deploy community plugin](https://github.com/wighawag/hardhat-deploy/tree/master).
 
 ### Truffle 4 and Web3.js' synchronous calls
 


### PR DESCRIPTION
The Truffle migrations page was out of date, incorrectly claiming that no plugins yet exist which implement a deployment system for Hardhat.  However since that was written, hardhat-deploy has emerged, and the same text in `/guides/deploying.md` was already updated accordingly.

So update the paragraph in `truffle-migration.md` to match, and cross-link to `/guides/deploying.md`.

This is relevant to the discussion in #381.

- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.