### PR TITLE
Bump uuid to ^8.3.2 and @types/uuid to ^8.3.1

### DIFF
--- a/.changeset/cold-ligers-divide.md
+++ b/.changeset/cold-ligers-divide.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Bump uuid package to remove a deprecation warning (thanks @yhuard!)

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -70,7 +70,7 @@
     "@types/resolve": "^1.17.1",
     "@types/semver": "^6.0.2",
     "@types/sinon": "^9.0.8",
-    "@types/uuid": "^3.4.5",
+    "@types/uuid": "^8.3.1",
     "@types/ws": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
@@ -136,7 +136,7 @@
     "stacktrace-parser": "^0.1.10",
     "true-case-path": "^2.2.1",
     "tsort": "0.0.1",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },
   "nyc": {

--- a/packages/hardhat-core/src/internal/cli/analytics.ts
+++ b/packages/hardhat-core/src/internal/cli/analytics.ts
@@ -3,7 +3,7 @@ import debug from "debug";
 import fetch from "node-fetch";
 import os from "os";
 import qs from "qs";
-import uuid from "uuid/v4";
+import { v4 as uuid } from "uuid";
 
 import * as builtinTaskNames from "../../builtin-tasks/task-names";
 import { isLocalDev } from "../core/execution-mode";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,10 +2254,10 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.3.tgz#d6734f3741ce41b2630018c6b61c6745f6188c07"
   integrity sha512-Fl1TX1dapfXyDqFg2ic9M+vlXRktcPJrc4PR7sRc7sdVrjavg/JHlbUXBt8qWWqhJrmSqg3RNAkAPRiOYw6Ahw==
 
-"@types/uuid@^3.4.5":
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.10.tgz#637d3c8431f112edf6728ac9bdfadfe029540f48"
-  integrity sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==
+"@types/uuid@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@types/web3@1.0.19":
   version "1.0.19"
@@ -14882,6 +14882,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Hi! Here's a quick PR to bump `uuid` to the latest version. The reason is that currently, when we install `hardhat` in our projects, we get the following warning:

```
warning hardhat > uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

This PR fixes it. It follows the upgrading guidelines from https://www.npmjs.com/package/uuid#upgrading-from-uuid3x.

There are also 2 more warnings that are **not** covered by this PR:

```
warning hardhat > mocha > debug@3.2.6: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning hardhat > mocha > chokidar > fsevents@2.1.3: "Please update to latest v2.3 or v2.2"
```

For these 2 warnings, upgrading to `mocha` ^8 or ^9 is required, since there's no fix in the ^7 line. Do you have any plans for upgrading Mocha?

Thanks for this great project by the way 👍 