### PR TITLE
Fix github actions globs

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/e2e/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/e2e/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/e2e/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/e2e/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-ethers-ci.yml
+++ b/.github/workflows/hardhat-ethers-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-ethers/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-ethers/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-ethers/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-ethers/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-etherscan-ci.yml
+++ b/.github/workflows/hardhat-etherscan-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-etherscan/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-etherscan/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-etherscan/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-etherscan/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-ganache-ci.yml
+++ b/.github/workflows/hardhat-ganache-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-ganache/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-ganache/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-ganache/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-ganache/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-network-forking-ci.yml
+++ b/.github/workflows/hardhat-network-forking-ci.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-network-tracing-ci.yml
+++ b/.github/workflows/hardhat-network-tracing-ci.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-shorthand-ci.yml
+++ b/.github/workflows/hardhat-shorthand-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-shorthand/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-shorthand/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-shorthand/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-shorthand/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-solhint-ci.yml
+++ b/.github/workflows/hardhat-solhint-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-solhint/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-solhint/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-solhint/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-solhint/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-solpp-ci.yml
+++ b/.github/workflows/hardhat-solpp-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-solpp/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-solpp/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-solpp/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-solpp/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-truffle4-ci.yml
+++ b/.github/workflows/hardhat-truffle4-ci.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-truffle4/**/*"
-      - "packages/hardhat-web3-legacy/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-truffle4/**"
+      - "packages/hardhat-web3-legacy/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-truffle4/**/*"
-      - "packages/hardhat-web3-legacy/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-truffle4/**"
+      - "packages/hardhat-web3-legacy/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-truffle5-ci.yml
+++ b/.github/workflows/hardhat-truffle5-ci.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-truffle5/**/*"
-      - "packages/hardhat-web3/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-truffle5/**"
+      - "packages/hardhat-web3/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-truffle5/**/*"
-      - "packages/hardhat-web3/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-truffle5/**"
+      - "packages/hardhat-web3/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-vyper-ci.yml
+++ b/.github/workflows/hardhat-vyper-ci.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-vyper/**/*"
-      - "packages/hardhat-docker/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-vyper/**"
+      - "packages/hardhat-docker/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-vyper/**/*"
-      - "packages/hardhat-docker/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-vyper/**"
+      - "packages/hardhat-docker/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-waffle-ci.yml
+++ b/.github/workflows/hardhat-waffle-ci.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-waffle/**/*"
-      - "packages/hardhat-ethers/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-waffle/**"
+      - "packages/hardhat-ethers/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-waffle/**/*"
-      - "packages/hardhat-ethers/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-waffle/**"
+      - "packages/hardhat-ethers/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-web3-ci.yml
+++ b/.github/workflows/hardhat-web3-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-web3/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-web3/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-web3/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-web3/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-web3-legacy-ci.yml
+++ b/.github/workflows/hardhat-web3-legacy-ci.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [$default-branch]
     paths:
-      - "packages/hardhat-web3-legacy/**/*"
-      - "packages/hardhat-core/**/*"
+      - "packages/hardhat-web3-legacy/**"
+      - "packages/hardhat-core/**"
       - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "config/**"
   pull_request:
     branches:
       - "*"
     paths:
-      - "packages/hardhat-web3-legacy/**/*"
-      - "packages/hardhat-core/**/*"
-      - "packages/hardhat-common/**/*"
-      - "config/**/*"
+      - "packages/hardhat-web3-legacy/**"
+      - "packages/hardhat-core/**"
+      - "packages/hardhat-common/**"
+      - "config/**"
 
 defaults:
   run:


### PR DESCRIPTION
This PR fixes how our github actions workflows defined the globs that are used to decide if they should be run based on the paths modified by a PR/push.

We were using `**/*` instead of jut `**`, so PRs that only modified top-level files within a package didn't trigger CI runs. For example changesets' PRs didn't.