### PR TITLE
fix hex of odd length for eth_getStorageAt call when forking arbitrum

### DIFF
--- a/.changeset/neat-cars-explain.md
+++ b/.changeset/neat-cars-explain.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+fix hex of odd length for eth_getStorageAt call when forking arbitrum

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/base-types.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/base-types.ts
@@ -80,12 +80,20 @@ export function rpcQuantityToBN(quantity: string): BN {
 }
 
 export function numberToRpcQuantity(n: number | BN): string {
+  return numberToRpcQuantityWithLeadingZeros(n, false);
+}
+
+export function numberToRpcQuantityWithLeadingZeros(
+  n: number | BN,
+  leadingZeros: boolean
+): string {
   assertHardhatInvariant(
     typeof n === "number" || BN.isBN(n),
     "Expected number"
   );
 
-  return `0x${n.toString(16)}`;
+  const s = n.toString(16);
+  return leadingZeros ? `0x${s.length % 2 ? "0" : ""}${s}` : `0x${s}`;
 }
 
 /**

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -4,7 +4,8 @@ import * as t from "io-ts";
 import path from "path";
 
 import {
-  numberToRpcQuantity,
+  numberToRpcQuantity, 
+  numberToRpcQuantityWithLeadingZeros,
   rpcData,
   rpcQuantity,
 } from "../../core/jsonrpc/types/base-types";
@@ -56,7 +57,7 @@ export class JsonRpcClient {
       "eth_getStorageAt",
       [
         address.toString(),
-        numberToRpcQuantity(position),
+        numberToRpcQuantityWithLeadingZeros(position, true),
         numberToRpcQuantity(blockNumber),
       ],
       rpcData,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->


- [x] This PR includes a **bug fix**, relevant tests have **NOT** been included - I tested locally only.


---

Fixes https://github.com/nomiclabs/hardhat/issues/1896

tested on:
- [x] Polygon - works
- [x] Arbitrum - works