### PR TITLE
Sync waffle plugins' hardhat devDependency to peerDependency

### DIFF
--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -51,7 +51,7 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.24.1",
     "eslint-plugin-prettier": "3.4.0",
-    "hardhat": "^2.0.0",
+    "hardhat": "^2.6.4",
     "mocha": "^7.1.2",
     "prettier": "2.3.2",
     "rimraf": "^3.0.2",

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -51,7 +51,7 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.24.1",
     "eslint-plugin-prettier": "3.4.0",
-    "hardhat": "^2.0.0",
+    "hardhat": "^2.6.4",
     "mocha": "^7.1.2",
     "prettier": "2.3.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Because `master` CI runs are failing like:
```
Run node scripts/check-dependencies.js
@nomiclabs/hardhat-truffle4 has different versions of hardhat as peerDependency and devDependency
@nomiclabs/hardhat-truffle5 has different versions of hardhat as peerDependency and devDependency
Error: Process completed with exit code 1.
```