### PR TITLE
List plugin that transfers Link token between accounts

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -402,6 +402,15 @@ const plugins = [
       "This plugin brings the proxy contract to Hardhat, which allows you to manage the proxy contract in a simple way.",
     tags: ["Proxy Contract", "Tasks", "Scripts"],
   },
+  {
+    name: "hardhat-fund-link",
+    author: "Applied Blockchain",
+    authorUrl: "https://github.com/appliedblockchain",
+    url: "https://github.com/appliedblockchain/chainlink-consumer/tree/master/plugins/fund-link",
+    description:
+      "Transfers Link token amount between accounts.",
+    tags: ["Chainlink", "Link"],
+  }
 ];
 
 module.exports = plugins.map((p) => ({

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -406,11 +406,11 @@ const plugins = [
     name: "hardhat-fund-link",
     author: "Applied Blockchain",
     authorUrl: "https://github.com/appliedblockchain",
-    url: "https://github.com/appliedblockchain/chainlink-consumer/tree/master/plugins/fund-link",
-    description:
-      "Transfers Link token amount between accounts.",
+    url:
+      "https://github.com/appliedblockchain/chainlink-consumer/tree/master/plugins/fund-link",
+    description: "Transfers Link token amount between accounts.",
     tags: ["Chainlink", "Link"],
-  }
+  },
 ];
 
 module.exports = plugins.map((p) => ({


### PR DESCRIPTION
- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.