### PR TITLE
Set the default NVM version to 16

### DIFF
--- a/docs/tutorial/setting-up-the-environment.md
+++ b/docs/tutorial/setting-up-the-environment.md
@@ -30,10 +30,10 @@ Make sure you have `git` installed. Otherwise, follow [these instructions](https
 There are multiple ways of installing Node.js on MacOS. We will be using [Node Version Manager (nvm)](http://github.com/creationix/nvm). Copy and paste these commands in a terminal:
 
 ```
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | bash
-nvm install 12
-nvm use 12
-nvm alias default 12
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+nvm install 16
+nvm use 16
+nvm alias default 16
 npm install npm --global # Upgrade npm to the latest version
 ```
 
@@ -46,7 +46,7 @@ Installing Node.js on Windows requires a few manual steps. We'll install git, No
 
 ## Upgrading your Node.js installation
 
-If your version of Node.js is older than `12.0` follow the instructions below to upgrade.
+If your version of Node.js is older than `16.0` follow the instructions below to upgrade.
 
 ### Linux
 
@@ -58,12 +58,12 @@ If your version of Node.js is older than `12.0` follow the instructions below to
 
 ### MacOS
 
-You can change your Node.js version using [nvm](http://github.com/creationix/nvm). To upgrade to Node.js `12.x` run these in a terminal:
+You can change your Node.js version using [nvm](http://github.com/creationix/nvm). To upgrade to Node.js `16.x` run these in a terminal:
 
 ```
-nvm install 12
-nvm use 12
-nvm alias default 12
+nvm install 16
+nvm use 16
+nvm alias default 16
 npm install npm --global # Upgrade npm to the latest version
 ```
 


### PR DESCRIPTION
NVM versions < 16 cause a memory fault issue on Macs with the M1 processor at this step: 
https://hardhat.org/tutorial/testing-contracts.html 

because of this error: 
https://stackoverflow.com/questions/65856300/wasm-code-commit-allocation-failed-process-out-of-memory

Hopefully this is helpful?

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
