### PR TITLE
Fix documentation mismatch and add one more unit testing example.

### DIFF
--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -65,7 +65,7 @@ Now you're ready to run the script:
 
 ```
 $ node scripts/sample-script.js
-Greeter address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+Greeter deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 ```
 
 By accessing the [Hardhat Runtime Environment] at the top, you are allowed to run the script in a standalone fashion. Hardhat always runs the compile task when it's invoked via `npx hardhat run`, but in a standalone fashion you may want to call compile manually to make sure everything is compiled. This is done by calling `hre.run('compile')`. Uncomment the following line and re-run the script with `node`:
@@ -76,7 +76,7 @@ await hre.run("compile");
 
 ```
 $ node scripts/sample-script.js
-Greeter address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+Greeter deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 ```
 
 ### Hardhat arguments

--- a/docs/guides/waffle-testing.md
+++ b/docs/guides/waffle-testing.md
@@ -155,6 +155,22 @@ Finally, to execute a contract's method from another account, all you need to do
 await greeter.connect(addr1).setGreeting("Hallo, Erde!");
 ```
 
+### Testing from an unauthorized account
+
+If you'd like to test your contract from a different, but unauthorized account, for example if you expect a transaction failure, then  you can use the [Waffle Chai revert matcher](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html?highlight=revertedwith#revert):
+
+```js
+const [owner, unauthorizedUser] = await ethers.getSigners();
+await expect(
+      greeter.connect(unauthorizedUser).sendTokens()
+    ).to.be.revertedWith("Ownable: caller is not the owner");
+// you can also do this:
+await expect(
+      greeter.connect(unauthorizedUser).sendTokens()
+    ).to.be.reverted;
+```
+
+
 ## Migrating an existing Waffle project
 
 If you're starting a project from scratch and looking to use Waffle, you can skip this section. If you're setting up an existing Waffle project to use Hardhat you'll need to migrate the [configuration options](https://ethereum-waffle.readthedocs.io/en/latest/configuration.html) Waffle offers. The following table maps Waffle configurations to their Hardhat equivalents:


### PR DESCRIPTION
- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

This PR improves 2 things:
- Fixes a mismatch in documentation. It says the deploy-script will act one way, and it says that the result will look another way. This refers to the `sample-script.js` output in https://hardhat.org/guides/scripts.html
- It adds one more example for unit testing with another account using the `connect()` function. I feel like this documentation fell short in the example of `Testing from a different account`.

The mismatch fix:
![Screen Shot 2021-10-03 at 8 27 50 PM](https://user-images.githubusercontent.com/6848941/135788775-26bb8828-c48e-445e-9453-3e0a17e0b9c2.png)

The extra Unit Testing example:
![Screen Shot 2021-10-03 at 8 25 15 PM](https://user-images.githubusercontent.com/6848941/135788825-db4facdd-f303-409f-ac11-e70c0855a197.png)
