### PR TITLE
Added hardhat_getAutomine JSON-RPC call

### DIFF
--- a/.changeset/giant-panthers-repeat.md
+++ b/.changeset/giant-panthers-repeat.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"docs": patch
+---
+
+Add a new `hardhat_getAutomine` JSON-RPC method to Hardhat Network that returns `true` if automining is enabled and `false` if it's not.

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -322,7 +322,7 @@ Call [`hardhat_stopImpersonatingAccount`](#hardhat-stopimpersonatingaccount) to 
 
 #### `hardhat_getAutomine`
 
-Get the current status of the automatic mining behavior.
+Returns `true` if automatic mining is enabled, and `false` otherwise. See [Mining Modes](../explanation/mining-modes.md) to learn more.
 
 #### `hardhat_reset`
 
@@ -440,7 +440,7 @@ Same as Ganache.
 
 #### `evm_setAutomine`
 
-Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network. See also [Mining Modes](../explanation/mining-modes.md).
+Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network. You can use [`hardhat_getAutomine`](#hardhat_getautomine) to get the current value. See also [Mining Modes](../explanation/mining-modes.md).
 
 #### `evm_setBlockGasLimit`
 

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -320,6 +320,10 @@ Call [`hardhat_stopImpersonatingAccount`](#hardhat-stopimpersonatingaccount) to 
 #### `hardhat_intervalMine`
 -->
 
+#### `hardhat_getAutomine`
+
+Get the current status of the automatic mining behavior.
+
 #### `hardhat_reset`
 
 See the [Mainnet Forking guide](../guides/mainnet-forking.md)

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -440,7 +440,7 @@ Same as Ganache.
 
 #### `evm_setAutomine`
 
-Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network. You can use [`hardhat_getAutomine`](#hardhat_getautomine) to get the current value. See also [Mining Modes](../explanation/mining-modes.md).
+Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network. You can use [`hardhat_getAutomine`](#hardhat-getautomine) to get the current value. See also [Mining Modes](../explanation/mining-modes.md).
 
 #### `evm_setBlockGasLimit`
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
@@ -66,6 +66,9 @@ export class HardhatModule {
       case "hardhat_intervalMine":
         return this._intervalMineAction(...this._intervalMineParams(params));
 
+      case "hardhat_getAutomine":
+        return this._getAutomine();
+
       case "hardhat_stopImpersonatingAccount":
         return this._stopImpersonatingAction(
           ...this._stopImpersonatingParams(params)
@@ -182,6 +185,12 @@ export class HardhatModule {
     }
 
     return true;
+  }
+
+  // hardhat_getAutomine
+
+  private async _getAutomine(): Promise<boolean> {
+    return this._node.getAutomine();
   }
 
   // hardhat_stopImpersonatingAccount

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -1103,6 +1103,10 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     this._automine = automine;
   }
 
+  public getAutomine() {
+    return this._automine;
+  }
+
   public async setBlockGasLimit(gasLimit: BN | number) {
     this._txPool.setBlockGasLimit(gasLimit);
     await this._txPool.updatePendingAndQueued();

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -176,6 +176,19 @@ describe("Hardhat module", function () {
         });
       });
 
+      describe("hardhat_getAutomine", () => {
+        it("should return automine status true when enabled", async function () {
+          await this.provider.send("evm_setAutomine", [true]);
+          const result = await this.provider.send("hardhat_getAutomine");
+          assert.isTrue(result);
+        });
+        it("should return automine status false when disabled", async function () {
+          await this.provider.send("evm_setAutomine", [false]);
+          const result = await this.provider.send("hardhat_getAutomine");
+          assert.isFalse(result);
+        });
+      });
+
       describe("hardhat_reset", function () {
         before(function () {
           if (ALCHEMY_URL === undefined) {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **documentation change**, it uses the `master` branch as its base branch.
- [x] Because this PR includes a **new feature**, it uses the `development` branch as its base branch.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

This pull request fixes https://github.com/nomiclabs/hardhat/issues/2010 by creating a `hardhat_getAutomine` JSON-RPC call that retrieves the `Node` `_automine` private member variable.

The changes focus on adding this functionality, test cases, and associated documentation, considering @alcuadrado's recommendation about using `hardhat_getAutomine` instead of `evm_getAutomine` for not introducing non-standard JSON-RPC calls into the `evm` provider.

A screenshot of the successful test cases execution is attached below.
![image](https://user-images.githubusercontent.com/25695302/139604387-1677091c-857b-4640-b13f-c03458c81e20.png)

I appreciate that you take care when reviewing, as this is one of my first contributions to this exciting project.