### PR TITLE
add xdeployer plugin

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -278,6 +278,15 @@ module.exports.communityPlugins = [
       "ethers.js",
     ],
   },
+  {
+    name: "xdeployer",
+    author: "Pascal Marco Caversaccio",
+    authorUrl: "https://github.com/pcaversaccio",
+    url: "https://github.com/pcaversaccio/xdeployer",
+    description:
+      "Hardhat plugin to deploy your smart contracts across multiple EVM chains with the same deterministic address.",
+    tags: ["Deployment", "CREATE2", "Tasks"],
+  },
 ];
 
 module.exports.officialPlugins = [

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -282,7 +282,6 @@ module.exports.communityPlugins = [
     name: "xdeployer",
     author: "Pascal Marco Caversaccio",
     authorUrl: "https://github.com/pcaversaccio",
-    url: "https://github.com/pcaversaccio/xdeployer",
     description:
       "Hardhat plugin to deploy your smart contracts across multiple EVM chains with the same deterministic address.",
     tags: ["Deployment", "CREATE2", "Tasks"],


### PR DESCRIPTION
- [x] Because this PR includes a **documentation change**, it uses the `master` branch as its base branch.
---
**Plugin Description:**
Hardhat plugin to deploy your smart contracts across multiple Ethereum Virtual Machine (EVM) chains with the same deterministic address. Currently only preselected test networks are supported. Production networks will be added as we move into a wider beta phase.
