### PR TITLE
Avalanche verify support

### DIFF
--- a/.changeset/cool-rats-do.md
+++ b/.changeset/cool-rats-do.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+Add support for the Avalanche Mainnet and Fuji chains (thanks @marcelomorgado!)

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -40,6 +40,9 @@ enum NetworkID {
   // Arbitrum
   ARBITRUM_ONE = 42161,
   ARBITRUM_TESTNET = 421611,
+  // Avalanche
+  AVALANCHE = 43114,
+  AVALANCHE_FUJI_TESTNET = 43113,
 }
 
 const networkIDtoEndpoints: NetworkMap = {
@@ -110,6 +113,14 @@ const networkIDtoEndpoints: NetworkMap = {
   [NetworkID.ARBITRUM_TESTNET]: {
     apiURL: "https://api-testnet.arbiscan.io/api",
     browserURL: "https://testnet.arbiscan.io/",
+  },
+  [NetworkID.AVALANCHE]: {
+    apiURL: "https://api.snowtrace.io/api",
+    browserURL: "https://snowtrace.io/",
+  },
+  [NetworkID.AVALANCHE_FUJI_TESTNET]: {
+    apiURL: "https://api-testnet.snowtrace.io/api",
+    browserURL: "https://testnet.snowtrace.io/",
   },
 };
 


### PR DESCRIPTION
- [X] Because this PR includes a **new feature**, it uses the `development` branch as its base branch.
---

<!-- Add a description of your PR here -->

Support contracts verification for the snowtrace.io (Etherscan-like Avalanche explorer)