### PR TITLE
hardhat-etherscan: Added avalanche snowtrace.io support

### DIFF
--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -40,6 +40,9 @@ enum NetworkID {
   // Arbitrum
   ARBITRUM_ONE = 42161,
   ARBITRUM_TESTNET = 421611,
+  // Avalanche
+  AVALANCHE = 43114,
+  AVALANCHE_FUJI = 43113,
 }
 
 const networkIDtoEndpoints: NetworkMap = {
@@ -110,6 +113,14 @@ const networkIDtoEndpoints: NetworkMap = {
   [NetworkID.ARBITRUM_TESTNET]: {
     apiURL: "https://api-testnet.arbiscan.io/api",
     browserURL: "https://testnet.arbiscan.io/",
+  },
+  [NetworkID.AVALANCHE]: {
+    apiURL: "https://api.snowtrace.io/api",
+    browserURL: "https://snowtrace.io/",
+  },
+  [NetworkID.AVALANCHE_FUJI]: {
+    apiURL: "https://api-testnet.snowtrace.io/api",
+    browserURL: "https://testnet.snowtrace.io/",
   },
 };
 


### PR DESCRIPTION
Adding avalanche snowtrace.io support for automated etherscan verification :partying_face: 

Warm regards from rugdoc.io and thank you for all your hard work building such awesome infrastructure for all of us! 