### PR TITLE
Use Levenshtein distance to display similar artifact names if given name is not found

### DIFF
--- a/.changeset/rich-chefs-attack.md
+++ b/.changeset/rich-chefs-attack.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Display similar artifact names in error output if given name is not found (#201)

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -432,7 +432,7 @@ export class Artifacts implements IArtifacts {
       default:
         return `We found some that were similar:
 
-${names.join(os.EOL)}
+${names.map((n) => `  * ${n}`).join(os.EOL)}
 
 Please replace "${contractName}" for the correct contract name wherever you are trying to read its artifact.
 `;

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -504,9 +504,7 @@ Please replace "${contractName}" for the correct contract name wherever you are 
       if (occurrences > 1) {
         for (const file of files) {
           if (path.basename(file) === `${name}.json`) {
-            outputNames.push(
-              path.normalize(this._getFullyQualifiedNameFromPath(file))
-            );
+            outputNames.push(this._getFullyQualifiedNameFromPath(file));
           }
         }
         continue;
@@ -590,9 +588,9 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     }
 
     if (matchingFiles.length > 1) {
-      const candidates = matchingFiles
-        .map((file) => this._getFullyQualifiedNameFromPath(file))
-        .map(path.normalize);
+      const candidates = matchingFiles.map((file) =>
+        this._getFullyQualifiedNameFromPath(file)
+      );
 
       throw new HardhatError(ERRORS.ARTIFACTS.MULTIPLE_FOUND, {
         contractName,

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -490,13 +490,13 @@ export class Artifacts implements IArtifacts {
     for (const nameGroup of groupBy(similarNames).entries()) {
       if (nameGroup.length > 1) {
         const name = nameGroup[0];
-        const matchingFiles = files.filter(
-          (file) => path.basename(file) === `${name}.json`
-        );
-        const candidates = matchingFiles
-          .map(this._getFullyQualifiedNameFromPath)
-          .map(path.normalize);
-        outputNames.push(...candidates);
+        for (const file of files) {
+          if (path.basename(file) === `${name}.json`) {
+            outputNames.push(
+              path.normalize(this._getFullyQualifiedNameFromPath(file))
+            );
+          }
+        }
         continue;
       }
 

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -73,7 +73,7 @@ export class Artifacts implements IArtifacts {
     fullyQualifiedName: string
   ): Promise<BuildInfo | undefined> {
     const artifactPath =
-      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
+      this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     const debugFilePath = this._getDebugFilePath(artifactPath);
     const buildInfoPath = await this._getBuildInfoFromDebugFile(debugFilePath);
@@ -116,7 +116,7 @@ export class Artifacts implements IArtifacts {
     );
 
     const artifactPath =
-      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
+      this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     await fsExtra.ensureDir(path.dirname(artifactPath));
 
@@ -223,6 +223,18 @@ export class Artifacts implements IArtifacts {
     }
   }
 
+  /**
+   * Returns the absolute path to the given artifact
+   */
+  public formArtifactPathFromFullyQualifiedName(
+    fullyQualifiedName: string
+  ): string {
+    const { sourceName, contractName } =
+      parseFullyQualifiedName(fullyQualifiedName);
+
+    return path.join(this._artifactsPath, sourceName, `${contractName}.json`);
+  }
+
   private _getBuildInfoName(
     solcVersion: string,
     solcLongVersion: string,
@@ -250,7 +262,7 @@ export class Artifacts implements IArtifacts {
    */
   private async _getArtifactPath(name: string): Promise<string> {
     if (isFullyQualifiedName(name)) {
-      return this._getArtifactPathFromFullyQualifiedName(name);
+      return this._getValidArtifactPathFromFullyQualifiedName(name);
     }
 
     const files = await this.getArtifactPaths();
@@ -301,7 +313,7 @@ export class Artifacts implements IArtifacts {
    */
   private _getArtifactPathSync(name: string): string {
     if (isFullyQualifiedName(name)) {
-      return this._getArtifactPathFromFullyQualifiedNameSync(name);
+      return this._getValidArtifactPathFromFullyQualifiedNameSync(name);
     }
 
     const files = this._getArtifactPathsSync();
@@ -357,17 +369,27 @@ export class Artifacts implements IArtifacts {
     }
   }
 
-  private async _getArtifactPathFromFullyQualifiedName(
+  /**
+   * DO NOT DELETE OR CHANGE
+   *
+   * use this.formArtifactPathFromFullyQualifiedName instead
+   * @deprecated until typechain migrates to public version
+   * @see https://github.com/dethcrypto/TypeChain/issues/544
+   */
+  private _getArtifactPathFromFullyQualifiedName(
     fullyQualifiedName: string
-  ): Promise<string> {
+  ): string {
     const { sourceName, contractName } =
       parseFullyQualifiedName(fullyQualifiedName);
 
-    const artifactPath = path.join(
-      this._artifactsPath,
-      sourceName,
-      `${contractName}.json`
-    );
+    return path.join(this._artifactsPath, sourceName, `${contractName}.json`);
+  }
+
+  private async _getValidArtifactPathFromFullyQualifiedName(
+    fullyQualifiedName: string
+  ): Promise<string> {
+    const artifactPath =
+      this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     const trueCaseArtifactPath = await this._trueCasePath(
       path.relative(this._artifactsPath, artifactPath),
@@ -523,20 +545,11 @@ export class Artifacts implements IArtifacts {
     return mostSimilarNames;
   }
 
-  private _formArtifactPathFromFullyQualifiedNameSync(
-    fullyQualifiedName: string
-  ): string {
-    const { sourceName, contractName } =
-      parseFullyQualifiedName(fullyQualifiedName);
-
-    return path.join(this._artifactsPath, sourceName, `${contractName}.json`);
-  }
-
-  private _getArtifactPathFromFullyQualifiedNameSync(
+  private _getValidArtifactPathFromFullyQualifiedNameSync(
     fullyQualifiedName: string
   ): string {
     const artifactPath =
-      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
+      this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     const trueCaseArtifactPath = this._trueCasePathSync(
       path.relative(this._artifactsPath, artifactPath),

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -404,6 +404,13 @@ export class Artifacts implements IArtifacts {
     fullyQualifiedName: string
   ): never {
     const names = this._getAllFullyQualifiedNamesSync();
+
+    if (names.length === 0) {
+      throw new HardhatError(ERRORS.ARTIFACTS.NOT_FOUND, {
+        fullyQualifiedName,
+      });
+    }
+
     const similarNames = this._getSimilarContractNames(
       fullyQualifiedName,
       names
@@ -420,6 +427,13 @@ export class Artifacts implements IArtifacts {
     files: string[]
   ): never {
     const names = this._getAllContractNamesFromFiles(files);
+
+    if (names.length === 0) {
+      throw new HardhatError(ERRORS.ARTIFACTS.NOT_FOUND, {
+        contractName,
+      });
+    }
+
     const similarNames = this._getSimilarContractNames(contractName, names);
 
     if (similarNames.length === 1) {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -483,13 +483,14 @@ export class Artifacts implements IArtifacts {
     files: string[],
     similarNames: string[]
   ): never {
-    const groupBy = require("lodash/groupBy");
     const outputNames = [];
+    const groups = similarNames.reduce((obj, cur) => {
+      obj[cur] = obj[cur] ? obj[cur] + 1 : 1;
+      return obj;
+    }, {} as { [k: string]: number });
 
-    // groupBy(similarNames) === { Greeter: ['Greeter', 'Greeter'], Greater: ['Greater'] }
-    for (const nameGroup of groupBy(similarNames).entries()) {
-      if (nameGroup.length > 1) {
-        const name = nameGroup[0];
+    for (const [name, occurrances] of Object.entries(groups)) {
+      if (occurrances > 1) {
         for (const file of files) {
           if (path.basename(file) === `${name}.json`) {
             outputNames.push(
@@ -500,7 +501,7 @@ export class Artifacts implements IArtifacts {
         continue;
       }
 
-      outputNames.push(nameGroup[0]);
+      outputNames.push(name);
     }
 
     throw new HardhatError(ERRORS.ARTIFACTS.TYPO_SUGGESTION, {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -469,14 +469,18 @@ export class Artifacts implements IArtifacts {
   }
 
   /**
-   * cases:
-   *  given: 'Greter'
-   *    'contracts/Greeter.sol:Greeter'
-   *    'contracts/Meeter.sol:Greeter'
-   *    'Greater'
+   * If the project has these contracts:
+   *   - 'contracts/Greeter.sol:Greeter'
+   *   - 'contracts/Meeter.sol:Greeter'
+   *   - 'contracts/Greater.sol:Greater'
+   *  And the user tries to get an artifact with the name 'Greter', then
+   *  the suggestions will be 'Greeter', 'Greeter', and 'Greater'.
    *
-   *  'Greeter', 'Greeter', and 'Greater' are all 1 edit-distance away from 'Greter'
-   *  because user gave contract name here, we want to display fqn's for duplicates in `similarNames`
+   * We don't want to show duplicates here, so we use FQNs for those. The
+   * suggestions will then be:
+   *   - 'contracts/Greeter.sol:Greeter'
+   *   - 'contracts/Meeter.sol:Greeter'
+   *   - 'Greater'
    */
   private _handleMultipleSimilarContractNames(
     contractName: string,
@@ -489,8 +493,8 @@ export class Artifacts implements IArtifacts {
       return obj;
     }, {} as { [k: string]: number });
 
-    for (const [name, occurrances] of Object.entries(groups)) {
-      if (occurrances > 1) {
+    for (const [name, occurrences] of Object.entries(groups)) {
+      if (occurrences > 1) {
         for (const file of files) {
           if (path.basename(file) === `${name}.json`) {
             outputNames.push(

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -73,7 +73,7 @@ export class Artifacts implements IArtifacts {
     fullyQualifiedName: string
   ): Promise<BuildInfo | undefined> {
     const artifactPath =
-      this._getArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
+      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
 
     const debugFilePath = this._getDebugFilePath(artifactPath);
     const buildInfoPath = await this._getBuildInfoFromDebugFile(debugFilePath);
@@ -116,7 +116,7 @@ export class Artifacts implements IArtifacts {
     );
 
     const artifactPath =
-      this._getArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
+      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
 
     await fsExtra.ensureDir(path.dirname(artifactPath));
 
@@ -509,17 +509,20 @@ export class Artifacts implements IArtifacts {
     return mostSimilarNames;
   }
 
-  private _getArtifactPathFromFullyQualifiedNameSync(
+  private _formArtifactPathFromFullyQualifiedNameSync(
     fullyQualifiedName: string
   ): string {
     const { sourceName, contractName } =
       parseFullyQualifiedName(fullyQualifiedName);
 
-    const artifactPath = path.join(
-      this._artifactsPath,
-      sourceName,
-      `${contractName}.json`
-    );
+    return path.join(this._artifactsPath, sourceName, `${contractName}.json`);
+  }
+
+  private _getArtifactPathFromFullyQualifiedNameSync(
+    fullyQualifiedName: string
+  ): string {
+    const artifactPath =
+      this._formArtifactPathFromFullyQualifiedNameSync(fullyQualifiedName);
 
     const trueCaseArtifactPath = this._trueCasePathSync(
       path.relative(this._artifactsPath, artifactPath),

--- a/packages/hardhat-core/src/internal/constants.ts
+++ b/packages/hardhat-core/src/internal/constants.ts
@@ -24,6 +24,7 @@ export const ARTIFACT_FORMAT_VERSION = "hh-sol-artifact-1";
 export const DEBUG_FILE_FORMAT_VERSION = "hh-sol-dbg-1";
 export const BUILD_INFO_FORMAT_VERSION = "hh-sol-build-info-1";
 export const BUILD_INFO_DIR_NAME = "build-info";
+export const EDIT_DISTANCE_THRESHOLD = 3;
 
 export const HARDHAT_NETWORK_RESET_EVENT = "hardhatNetworkReset";
 export const HARDHAT_NETWORK_REVERT_SNAPSHOT_EVENT =

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -884,7 +884,7 @@ Please use a newer, supported version.`,
   ARTIFACTS: {
     NOT_FOUND: {
       number: 700,
-      message: 'Artifact for contract "%contractName%" not found.',
+      message: 'Artifact for contract "%contractName%" not found. %suggestion%',
       title: "Artifact not found",
       description: `Tried to import a nonexistent artifact.
 
@@ -914,21 +914,6 @@ Please use the fully qualified name of the contract to disambiguate it.`,
       
 Hardhat's artifact resolution is case sensitive to ensure projects are portable across different operating systems.`,
       shouldBeReported: true,
-    },
-    TYPO_SUGGESTION: {
-      number: 703,
-      message: `Artifact for contract "%contractName%" not found, but we found some that were similar:
-
-%similarNames%
-
-Please replace "%contractName%" for the correct contract name wherever you are trying to read its artifact.
-`,
-      title: "Similar artifacts found",
-      description: `Hardhat has detected that there may be a typo in the given contract name.
-
-Please double check your spelling of the requested contract name.
-`,
-      shouldBeReported: false,
     },
   },
   PLUGINS: {

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -921,7 +921,7 @@ Hardhat's artifact resolution is case sensitive to ensure projects are portable 
 
 %similarNames%
 
-Please replace %contractName% for the correct contract name wherever you are trying to read its artifact.
+Please replace "%contractName%" for the correct contract name wherever you are trying to read its artifact.
 `,
       title: "Similar artifacts found",
       description: `Hardhat has detected that there may be a typo in the given contract name.

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -915,6 +915,21 @@ Please use the fully qualified name of the contract to disambiguate it.`,
 Hardhat's artifact resolution is case sensitive to ensure projects are portable across different operating systems.`,
       shouldBeReported: true,
     },
+    TYPO_SUGGESTION: {
+      number: 703,
+      message: `Artifact for contract "%contractName%" not found, but we found some that were similar:
+
+%similarNames%
+
+Please replace %contractName% for the correct contract name wherever you are trying to read its artifact.
+`,
+      title: "Similar artifacts found",
+      description: `Hardhat has detected that there may be a typo in the given contract name.
+
+Please double check your spelling of the requested contract name.
+`,
+      shouldBeReported: false,
+    },
   },
   PLUGINS: {
     BUIDLER_PLUGIN: {

--- a/packages/hardhat-core/src/utils/contract-names.ts
+++ b/packages/hardhat-core/src/utils/contract-names.ts
@@ -56,3 +56,115 @@ export function parseName(name: string): {
 
   return { sourceName, contractName };
 }
+
+/**
+ * Returns the edit-distance between two given strings using Levenshtein distance.
+ *
+ * @param a First string being compared
+ * @param b Second string being compared
+ * @returns distance between the two strings (lower number == more similar)
+ * @see https://github.com/gustf/js-levenshtein
+ * @license MIT - https://github.com/gustf/js-levenshtein/blob/master/LICENSE
+ */
+export function findDistance(a: string, b: string): number {
+  function _min(
+    _d0: number,
+    _d1: number,
+    _d2: number,
+    _bx: number,
+    _ay: number
+  ): number {
+    return _d0 < _d1 || _d2 < _d1
+      ? _d0 > _d2
+        ? _d2 + 1
+        : _d0 + 1
+      : _bx === _ay
+      ? _d1
+      : _d1 + 1;
+  }
+
+  if (a === b) {
+    return 0;
+  }
+
+  if (a.length > b.length) {
+    [a, b] = [b, a];
+  }
+
+  let la = a.length;
+  let lb = b.length;
+
+  while (la > 0 && a.charCodeAt(la - 1) === b.charCodeAt(lb - 1)) {
+    la--;
+    lb--;
+  }
+
+  let offset = 0;
+
+  while (offset < la && a.charCodeAt(offset) === b.charCodeAt(offset)) {
+    offset++;
+  }
+
+  la -= offset;
+  lb -= offset;
+
+  if (la === 0 || lb < 3) {
+    return lb;
+  }
+
+  let x = 0;
+  let y: number;
+  let d0: number;
+  let d1: number;
+  let d2: number;
+  let d3: number;
+  let dd: number = 0; // typescript gets angry if we don't assign here
+  let dy: number;
+  let ay: number;
+  let bx0: number;
+  let bx1: number;
+  let bx2: number;
+  let bx3: number;
+
+  const vector = [];
+
+  for (y = 0; y < la; y++) {
+    vector.push(y + 1);
+    vector.push(a.charCodeAt(offset + y));
+  }
+
+  const len = vector.length - 1;
+
+  for (; x < lb - 3; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    bx1 = b.charCodeAt(offset + (d1 = x + 1));
+    bx2 = b.charCodeAt(offset + (d2 = x + 2));
+    bx3 = b.charCodeAt(offset + (d3 = x + 3));
+    dd = x += 4;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      ay = vector[y + 1];
+      d0 = _min(dy, d0, d1, bx0, ay);
+      d1 = _min(d0, d1, d2, bx1, ay);
+      d2 = _min(d1, d2, d3, bx2, ay);
+      dd = _min(d2, d3, dd, bx3, ay);
+      vector[y] = dd;
+      d3 = d2;
+      d2 = d1;
+      d1 = d0;
+      d0 = dy;
+    }
+  }
+
+  for (; x < lb; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    dd = ++x;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      vector[y] = dd = _min(dy, d0, dd, bx0, vector[y + 1]);
+      d0 = dy;
+    }
+  }
+
+  return dd;
+}

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -179,7 +179,7 @@ function isExplicitRelativePath(sourceName: string): boolean {
 }
 
 /**
- * This function replaces backslashes (\) with slashes (/).
+ * This function replaces backslashes (\\) with slashes (/).
  *
  * Note that a source name must not contain backslashes.
  */

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -532,7 +532,9 @@ describe("Artifacts class", function () {
       await artifacts.saveArtifactAndDebugFile(artifact2, "");
       await artifacts.saveArtifactAndDebugFile(artifact3, "");
 
-      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"].join(os.EOL);
+      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"]
+        .map((n) => `  * ${n}`)
+        .join(os.EOL);
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
@@ -556,7 +558,9 @@ describe("Artifacts class", function () {
       await artifacts.saveArtifactAndDebugFile(artifact2, "");
       await artifacts.saveArtifactAndDebugFile(artifact3, "");
 
-      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"].join(os.EOL);
+      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"]
+        .map((n) => `  * ${n}`)
+        .join(os.EOL);
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
@@ -578,7 +582,7 @@ describe("Artifacts class", function () {
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        "Lib.sol:Lib"
+        /Did you mean "Lib\.sol:Lib"?/
       );
     });
 
@@ -595,7 +599,7 @@ describe("Artifacts class", function () {
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        "Lib.sol:Lib"
+        /Did you mean "Lib\.sol:Lib"?/
       );
     });
 
@@ -612,10 +616,14 @@ describe("Artifacts class", function () {
       await artifacts.saveArtifactAndDebugFile(artifact, "");
       await artifacts.saveArtifactAndDebugFile(artifact2, "");
 
+      const expected = ["Lib.sol:Lob", "Lob.sol:Lib"]
+        .map((n) => `  * ${n}`)
+        .join(os.EOL);
+
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
+        expected
       );
     });
 
@@ -632,10 +640,14 @@ describe("Artifacts class", function () {
       await artifacts.saveArtifactAndDebugFile(artifact, "");
       await artifacts.saveArtifactAndDebugFile(artifact2, "");
 
+      const expected = ["Lib.sol:Lob", "Lob.sol:Lib"]
+        .map((n) => `  * ${n}`)
+        .join(os.EOL);
+
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
+        expected
       );
     });
 

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -495,8 +495,8 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
-        "Lib"
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /Did you mean "Lib"\?$/
       );
     });
 
@@ -512,8 +512,8 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
-        "Lib"
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /Did you mean "Lib"\?$/
       );
     });
 
@@ -536,7 +536,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         expected
       );
     });
@@ -560,7 +560,7 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         expected
       );
     });
@@ -577,7 +577,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         "Lib.sol:Lib"
       );
     });
@@ -594,7 +594,7 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         "Lib.sol:Lib"
       );
     });
@@ -614,7 +614,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
       );
     });
@@ -634,7 +634,7 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
       );
     });
@@ -651,7 +651,8 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.NOT_FOUND
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /not found\.\s*$/
       );
     });
 
@@ -667,7 +668,8 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.NOT_FOUND
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /not found\.\s*$/
       );
     });
 
@@ -683,7 +685,8 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        ERRORS.ARTIFACTS.NOT_FOUND
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /not found\.\s*$/
       );
     });
 
@@ -699,7 +702,8 @@ describe("Artifacts class", function () {
 
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
-        ERRORS.ARTIFACTS.NOT_FOUND
+        ERRORS.ARTIFACTS.NOT_FOUND,
+        /not found\.\s*$/
       );
     });
 

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -483,6 +483,162 @@ describe("Artifacts class", function () {
       );
     });
 
+    it("Should throw with typo suggestions when no artifacts match a given name (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        "Lib"
+      );
+    });
+
+    it("Should throw with typo suggestions when no artifacts match a given name (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        "Lib"
+      );
+    });
+
+    it("Should throw with fully qualified names for identical suggestions (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const name3 = "Lab";
+      const typo = "Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+      const artifact2 = getArtifactFromContractOutput("Lib2.sol", name, output);
+      const artifact3 = getArtifactFromContractOutput("Lab.sol", name3, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+      await artifacts.saveArtifactAndDebugFile(artifact2, "");
+      await artifacts.saveArtifactAndDebugFile(artifact3, "");
+
+      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"].join(os.EOL);
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        expected
+      );
+    });
+
+    it("Should throw with fully qualified names for identical suggestions (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const name3 = "Lab";
+      const typo = "Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+      const artifact2 = getArtifactFromContractOutput("Lib2.sol", name, output);
+      const artifact3 = getArtifactFromContractOutput("Lab.sol", name3, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+      await artifacts.saveArtifactAndDebugFile(artifact2, "");
+      await artifacts.saveArtifactAndDebugFile(artifact3, "");
+
+      const expected = ["Lab", "Lib.sol:Lib", "Lib2.sol:Lib"].join(os.EOL);
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        expected
+      );
+    });
+
+    it("Should throw with typo suggestions when no artifacts match a given fully qualified name (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lib.sol:Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        "Lib.sol:Lib"
+      );
+    });
+
+    it("Should throw with typo suggestions when no artifacts match a given fully qualified name (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lib.sol:Lob";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        "Lib.sol:Lib"
+      );
+    });
+
+    it("Should throw with multiple typo suggestions if they are the same distance from a given fully qualified name (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lob";
+      const name2 = "Lib";
+      const typo = "Lib.sol:Lib";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+      const artifact2 = getArtifactFromContractOutput("Lob.sol", name2, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+      await artifacts.saveArtifactAndDebugFile(artifact2, "");
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
+      );
+    });
+
+    it("Should throw with multiple typo suggestions if they are the same distance from a given fully qualified name (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lob";
+      const name2 = "Lib";
+      const typo = "Lib.sol:Lib";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+      const artifact2 = getArtifactFromContractOutput("Lob.sol", name2, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+      await artifacts.saveArtifactAndDebugFile(artifact2, "");
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.TYPO_SUGGESTION,
+        `Lib.sol:Lob${os.EOL}Lob.sol:Lib`
+      );
+    });
+
     it("Should be possible to get all the fully qualified names of the artifacts", async function () {
       const artifacts = new Artifacts(this.tmpDir);
       await storeAllArtifacts("source.sol", artifacts);
@@ -502,6 +658,23 @@ describe("Artifacts class", function () {
       expected.sort();
 
       assert.deepEqual(names, expected);
+    });
+
+    it("Should be possible to get an absolute path to an artifact given a fully qualified name", async function () {
+      const name = "Lib";
+      const output = COMPILER_OUTPUTS.Lib;
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      const fullyQualifiedName = "Lib.sol:Lib";
+      const artifactPath =
+        artifacts.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
+
+      assert.isTrue(artifactPath.startsWith(this.tmpDir));
+      assert.isTrue(artifactPath.endsWith(".json"));
     });
 
     it("Should be possible to get a build info from a fully qualified name", async function () {

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -639,6 +639,70 @@ describe("Artifacts class", function () {
       );
     });
 
+    it("Should not throw with suggestions if the given contract name is further than EDIT_DISTANCE_THRESHOLD (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "aaaa";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.NOT_FOUND
+      );
+    });
+
+    it("Should not throw with suggestions if the given contract name is further than EDIT_DISTANCE_THRESHOLD (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "aaaa";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.NOT_FOUND
+      );
+    });
+
+    it("Should not throw with suggestions if the given fully qualified name is further than EDIT_DISTANCE_THRESHOLD (async)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lib.sol:aaaa";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      await expectHardhatErrorAsync(
+        () => artifacts.readArtifact(typo),
+        ERRORS.ARTIFACTS.NOT_FOUND
+      );
+    });
+
+    it("Should not throw with suggestions if the given fully qualified name is further than EDIT_DISTANCE_THRESHOLD (sync)", async function () {
+      const output = COMPILER_OUTPUTS.Lib;
+      const name = "Lib";
+      const typo = "Lib.sol:aaaa";
+
+      const artifact = getArtifactFromContractOutput("Lib.sol", name, output);
+
+      const artifacts = new Artifacts(this.tmpDir);
+      await artifacts.saveArtifactAndDebugFile(artifact, "");
+
+      expectHardhatError(
+        () => artifacts.readArtifactSync(typo),
+        ERRORS.ARTIFACTS.NOT_FOUND
+      );
+    });
+
     it("Should be possible to get all the fully qualified names of the artifacts", async function () {
       const artifacts = new Artifacts(this.tmpDir);
       await storeAllArtifacts("source.sol", artifacts);

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -582,7 +582,7 @@ describe("Artifacts class", function () {
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        /Did you mean "Lib\.sol:Lib"?/
+        /Did you mean "Lib\.sol:Lib"\?/
       );
     });
 
@@ -599,7 +599,7 @@ describe("Artifacts class", function () {
       expectHardhatError(
         () => artifacts.readArtifactSync(typo),
         ERRORS.ARTIFACTS.NOT_FOUND,
-        /Did you mean "Lib\.sol:Lib"?/
+        /Did you mean "Lib\.sol:Lib"\?/
       );
     });
 


### PR DESCRIPTION
Core feature goal: Implement an appropriate edit-distance algorithm (Levenshtein) to suggest similar artifacts if a requested artifact is not found (i.e. if a user made a typo in the name)

New functions:

Public:
- `formArtifactPathFromFullyQualifiedName`

Private:
- `_trueCasePath`
- `_trueCasePathSync`
- `_getAllContractNamesFromFiles`
- `_getAllFullyQualifiedNamesSync`
- `_handleWrongArtifactForFullyQualifiedName`
- `_handleWrongArtifactForContractName`
- `_handleMultipleSimilarContractNames`
- `_getSimilarContractNames`
- `findDistance` (Levenshtein logic)

Added Error 703: `ERRORS.ARTIFACTS.TYPO_SUGGESTION`
Example:
```
HardhatError: HH703: Artifact for contract "Lob" not found, but we found some that were similar:

Lab
Lib.sol:Lib
Lib2.sol:Lib

Please replace Lob for the correct contract name wherever you are trying to read its artifact.
```

Some existing functions were edited such as moving the `true-case-path` logic from `readArtifact` and `readArtifactSync` into `_getArtifactPathFromFullyQualifiedName` (now called `_getValidArtifactPathFromFullyQualifiedName` due to needing to keep the old function for TypeChain). 

The reasoning behind moving this logic is that it was only needed when the user passed in a fully qualified name, so its placement in the top-level public function was misleading. Moving it fully into the dedicated "fully qualified name" code path is clearer and doesn't make additional, unnecessary file system calls when a contract name is given instead of an FQN.
