### PR TITLE
Hardhat Yul Compiling Plugin

### DIFF
--- a/packages/hardhat-Yul/LICENSE
+++ b/packages/hardhat-Yul/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 ControlCplusControlV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/hardhat-Yul/README.md
+++ b/packages/hardhat-Yul/README.md
@@ -1,0 +1,41 @@
+
+# Yul and Yul+ Hardhat Plugin
+
+This a plugin for hardhat that allows the compilation of .yul and .yulp files. They are compiled into solc artifacts (Thanks to Yul+'s sig"" function) and are mostly identical to work with from there. Its important to note this plugin is still very much in the beta, and artifacts may need to cleared after each compile. Some changes must be made to the config file as well to get it working
+
+## Setting up a Yul+ Hardhat Project
+
+First run
+```
+npx hardhat init
+```
+
+and create a new typescript project.
+
+Next, edit your tsconfig.ts file and add the following compiler options
+```
+    "allowJs": true,
+    "noImplicitAny": false
+```
+Next, clone this repo and put it all in a "Plugin Folder", then drop this folder into the root of your project directory.
+
+Then, in your hardhatconfig.ts file, add 
+```
+import "./Plugin/src";
+```
+
+Now you have a fully setup Hardhat Yul+ Project!
+
+## Quick debugging
+
+You may need to install some js packages, namely "solc" and "yulp", however a quick npm install will fix this
+
+## Why Yul+?
+
+Yul+ is an amazing language that brings the efficiency gains of Yul by allowing explicit memory control, with features that increase ease of use, and a sig"" function allowing the generate ABI to be identical to that of a Solidity Contract. Yul+ was initially developed by Fuel Labs as they built out their l2 platform, and showed some impressive gas reductions, dropping the cost of the ENS by around 20%!
+
+Understanding the intermediate language of Yul as well will also improve the efficiency of some segments of Solidity you write with the inline assembly options.
+
+## Community
+
+I hope to build out more of the Yul+ Community, I will be setting up more later, but as for now feel free to add a PR to this plugin, or add to the tag on Github to increase the number of resources avaliable. I will also be making a tutorial series for people looking to learn the Yul+ language.

--- a/packages/hardhat-Yul/package.json
+++ b/packages/hardhat-Yul/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@ControlCplusControlV/hardhat-yul",
+  "version": "2.0.1",
+  "description": "Hardhat plugin to develop smart contracts in Yul",
+  "repository": "github:nomiclabs/hardhat",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-vyper",
+  "author": "Nomic Labs LLC",
+  "license": "MIT",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "keywords": [
+    "ethereum",
+    "smart-contracts",
+    "hardhat",
+    "hardhat-plugin",
+    "yul"
+  ],
+  "scripts": {
+    "lint": "yarn prettier --check && yarn eslint",
+    "lint:fix": "yarn prettier --write && yarn eslint --fix",
+    "eslint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "prettier": "prettier \"**/*.{js,md,json}\"",
+    "test": "mocha --recursive \"test/**/*.ts\" --exit",
+    "build": "tsc --build .",
+    "clean": "rimraf dist"
+  },
+  "files": [
+    "dist/src/",
+    "src/",
+    "LICENSE",
+    "README.md"
+  ],
+  "dependencies": {
+    "fs-extra": "^7.0.1",
+    "solpp": "^0.10.1",
+    "glob": "^7.1.3",
+    "@nomiclabs/hardhat-docker": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.2.0",
+    "@types/fs-extra": "^5.1.0",
+    "@types/glob": "^7.1.1",
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^10.17.24",
+    "@typescript-eslint/eslint-plugin": "4.29.2",
+    "@typescript-eslint/parser": "4.29.2",
+    "chai": "^4.2.0",
+    "eslint": "^7.29.0",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-import": "2.24.1",
+    "eslint-plugin-prettier": "3.4.0",
+    "hardhat": "^2.0.0",
+    "mocha": "^7.1.2",
+    "prettier": "2.3.2",
+    "rimraf": "^3.0.2",
+    "ts-node": "^8.1.0",
+    "typescript": "~4.0.3"
+  },
+  "peerDependencies": {
+    "hardhat": "^2.0.0"
+  }
+}

--- a/packages/hardhat-Yul/src/compilation.ts
+++ b/packages/hardhat-Yul/src/compilation.ts
@@ -1,0 +1,106 @@
+import fsExtra from "fs-extra";
+import { NomicLabsHardhatPluginError } from "hardhat/plugins";
+import { Artifact, Artifacts, ProjectPathsConfig } from "hardhat/types";
+import { localPathToSourceName } from "hardhat/utils/source-names";
+import path from "path";
+import solc = require('solc');
+import yulp = require('yulp');
+import * as fs from 'fs';
+import { YulConfig } from "./types";
+import { string } from "hardhat/internal/core/params/argumentTypes";
+
+
+export async function compile(
+  YulConfig: YulConfig,
+  paths: ProjectPathsConfig,
+  artifacts: Artifacts
+) {
+  const files = await getYulSources(paths);
+
+  let someContractFailed = false;
+
+  for (const file of files) {
+    const pathFromCWD = path.relative(process.cwd(), file);
+    const pathFromSources = path.relative(paths.sources, file);
+
+    console.log("Compiling", pathFromCWD);
+
+    let YulOutput = await compileYul(pathFromCWD, file)
+
+    const sourceName = await localPathToSourceName(paths.root, file);
+    const artifact = getArtifactFromYulOutput(sourceName, YulOutput);
+
+    await artifacts.saveArtifactAndDebugFile(artifact);
+
+  }
+}
+
+
+async function getYulSources(paths: ProjectPathsConfig) {
+  const glob = await import("glob");
+  const yulFiles = glob.sync(path.join(paths.sources, "**", "*.yul"));
+  const yulpFiles = glob.sync(path.join(paths.sources, "**", "*.yulp"));
+
+  return [...yulFiles, ...yulpFiles];
+}
+
+function pathToContractName(file: string) {
+  const sourceName = path.basename(file);
+  return sourceName.substring(0, sourceName.indexOf("."));
+}
+
+function getArtifactFromYulOutput(sourceName: string, output: any): Artifact {
+  const contractName = pathToContractName(sourceName);
+
+  return {
+    _format: "hh-sol-artifact-1", // sig"function add()" makes this work
+    contractName,
+    sourceName,
+    abi: output.abi,
+    bytecode: output.bytecode,
+    deployedBytecode: output.bytecode_runtime,
+    linkReferences: {},
+    deployedLinkReferences: {},
+  };
+}
+
+
+async function handleCommonErrors<T>(promise: Promise<T>): Promise<T> {
+  try {
+    return await promise;
+  } catch (error) {
+    throw error;
+  }
+}
+
+async function compileYul(filepath : string, filename : string) {
+  const data = fs.readFileSync(filepath, 'utf8');
+  const source = yulp.compile(data);
+  let output = JSON.parse(solc.compile(JSON.stringify({
+    "language": "Yul",
+    "sources": { "Target.yul": { "content": yulp.print(source.results) } },
+    "settings": {
+      "outputSelection": { "*": { "*": ["*"], "": [ "*" ] } },
+      "optimizer": {
+        "enabled": true,
+        "runs": 0,
+        "details": {
+          "yul": true
+        }
+      }
+    }
+  })));        
+  let contractObjects = Object.keys(output.contracts["Target.yul"])
+  let bytecode = "0x" + output.contracts["Target.yul"][contractObjects[0]]["evm"]["bytecode"]["object"];
+  let abi = source.signatures.map(v => v.abi.slice(4, -1)).concat(source.topics.map(v => v.abi.slice(6, -1)))
+  var contractCompiled = {
+    "_format": "hh-sol-artifact-1",
+    "sourceName" : filename,
+    "abi" : abi,
+    "bytecode" : bytecode,
+    "linkReferences": {}, // I really don't know what this means
+    "deployedLinkReferences": {} // This either
+  }
+
+  return contractCompiled;
+}

--- a/packages/hardhat-Yul/src/index.ts
+++ b/packages/hardhat-Yul/src/index.ts
@@ -1,0 +1,26 @@
+import { TASK_COMPILE_GET_COMPILATION_TASKS } from "hardhat/builtin-tasks/task-names";
+import { extendConfig, subtask } from "hardhat/internal/core/config/config-env";
+
+import { TASK_COMPILE_YUL } from "./task-names";
+import "./type-extensions";
+
+extendConfig((config) => {
+  const defaultConfig = { version: "latest" };
+  config.yul = { ...defaultConfig, ...config.yul };
+});
+
+subtask(
+  TASK_COMPILE_GET_COMPILATION_TASKS,
+  async (_, __, runSuper): Promise<string[]> => {
+    const otherTasks = await runSuper();
+    return [...otherTasks, TASK_COMPILE_YUL];
+  }
+);
+
+subtask(TASK_COMPILE_YUL, async (_, { config, artifacts }) => {
+  const { compile } = await import("./compilation");
+
+  // This plugin is experimental, so this task isn't split into multiple
+  // subtasks yet.
+  await compile(config.yul, config.paths, artifacts);
+});

--- a/packages/hardhat-Yul/src/task-names.ts
+++ b/packages/hardhat-Yul/src/task-names.ts
@@ -1,0 +1,1 @@
+export const TASK_COMPILE_YUL = "compile:yul";

--- a/packages/hardhat-Yul/src/type-extensions.ts
+++ b/packages/hardhat-Yul/src/type-extensions.ts
@@ -1,0 +1,13 @@
+import "hardhat/types/config";
+
+import { YulConfig } from "./types";
+
+declare module "hardhat/types/config" {
+  interface HardhatUserConfig {
+    yul?: Partial<YulConfig>;
+  }
+
+  interface HardhatConfig {
+    yul: YulConfig;
+  }
+}

--- a/packages/hardhat-Yul/src/types.ts
+++ b/packages/hardhat-Yul/src/types.ts
@@ -1,0 +1,3 @@
+export interface YulConfig {
+  version: string;
+}

--- a/packages/hardhat-Yul/tsconfig.json
+++ b/packages/hardhat-Yul/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../config/typescript/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "noImplicitAny": false // Typescript is more fun without the types
+  },
+  "exclude": ["./dist", "./node_modules", "./test/**/hardhat.config.ts"],
+  "references": [
+    {
+      "path": "../hardhat-core/src"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. I asked on discord in plugin development and was told to submit here
---

This plugin allows the use of Hardhat with the Yul+ and Yul target languages, as well as compilation of .yul and yulp files into solc artifacts. I've found it tremendously helpful when writing and debugging EVM assembly, and Yul+ (slightly better than raw assembly) and wanted to contribute it. It's a little rough atm lacking tests or descriptive errors, but its still much better than current Yul support.