### PR TITLE
Use 127.0.0.1 as default hostname

### DIFF
--- a/.changeset/selfish-falcons-decide.md
+++ b/.changeset/selfish-falcons-decide.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix an issue with new versions of Node.js that prevented clients from connecting to Hardhat's node using 127.0.0.1

--- a/packages/hardhat-core/src/builtin-tasks/node.ts
+++ b/packages/hardhat-core/src/builtin-tasks/node.ts
@@ -300,7 +300,7 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
           forkUrl,
         });
 
-        // the default hostname is "localhost" unless we are inside a docker
+        // the default hostname is "127.0.0.1" unless we are inside a docker
         // container, in that case we use "0.0.0.0"
         let hostname: string;
         if (hostnameParam !== undefined) {
@@ -310,7 +310,7 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
           if (insideDocker) {
             hostname = "0.0.0.0";
           } else {
-            hostname = "localhost";
+            hostname = "127.0.0.1";
           }
         }
 


### PR DESCRIPTION
Banteg originally reported that with the new version of Node.js he couldn't connect to `hardhat node`. The reason is that now node resolves `"localhost"` to an ipv6, so we only listen on ipv6 by default.

This PR fixes that by making it explicit that we want the ipv4 version of `localhost` (i.e. `127.0.0.1`)