### PR TITLE
Add Yul+ and Yul Plugin to Community Plugin Section

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -368,6 +368,14 @@ module.exports.officialPlugins = [
     description: "Adds support to compile Vyper smart contracts",
     tags: ["Vyper", "Compiler"],
   },
+    {
+    name: "@ControlCplusControlV/hardhat-Yul",
+    author: "ControlCplusControlV",
+    authorUrl: "https://github.com/controlCplusControlV/",
+    description:
+      "Hardhat plugin to compile the Yul and Yul+ languages into solc compatible artifacts. Works with .yul and .yulp file extensions",
+    tags: ["Deployment", "CREATE2", "Tasks"],
+  },
 ].map((p) => ({
   ...p,
   normalizedName: p.name.split("/").join("-").replace(/^@/, ""),

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -286,6 +286,14 @@ module.exports.communityPlugins = [
       "Hardhat plugin to deploy your smart contracts across multiple EVM chains with the same deterministic address.",
     tags: ["Deployment", "CREATE2", "Tasks"],
   },
+  {
+    name: "@ControlCplusControlV/hardhat-Yul",
+    author: "ControlCplusControlV",
+    authorUrl: "https://github.com/controlCplusControlV/",
+    description:
+      "Hardhat plugin to compile the Yul and Yul+ languages into solc compatible artifacts. Works with .yul and .yulp file extensions",
+    tags: ["Yul", "Assembly", "Compiler", "Yul+"],
+  },
 ];
 
 module.exports.officialPlugins = [
@@ -367,14 +375,6 @@ module.exports.officialPlugins = [
     authorUrl: "https://twitter.com/nomiclabs",
     description: "Adds support to compile Vyper smart contracts",
     tags: ["Vyper", "Compiler"],
-  },
-    {
-    name: "@ControlCplusControlV/hardhat-Yul",
-    author: "ControlCplusControlV",
-    authorUrl: "https://github.com/controlCplusControlV/",
-    description:
-      "Hardhat plugin to compile the Yul and Yul+ languages into solc compatible artifacts. Works with .yul and .yulp file extensions",
-    tags: ["Yul", "Assembly", "Compiler", "Yul+"],
   },
 ].map((p) => ({
   ...p,

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -374,7 +374,7 @@ module.exports.officialPlugins = [
     authorUrl: "https://github.com/controlCplusControlV/",
     description:
       "Hardhat plugin to compile the Yul and Yul+ languages into solc compatible artifacts. Works with .yul and .yulp file extensions",
-    tags: ["Deployment", "CREATE2", "Tasks"],
+    tags: ["Yul", "Assembly", "Compiler", "Yul+"],
   },
 ].map((p) => ({
   ...p,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.


---
@alcuadrado Moved the PR to over here

This plugin allows the use of Hardhat with the Yul+ and Yul target languages, as well as compilation of .yul and yulp files into solc artifacts. I've found it tremendously helpful when writing and debugging EVM assembly, and Yul+ (slightly better than raw assembly) and wanted to contribute it. It's a little rough atm lacking tests or descriptive errors, but its still much better than current Yul support.