### PR TITLE
Add Contract Verification support for Moonriver and Moonbase Alpha

### DIFF
--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -43,6 +43,9 @@ enum NetworkID {
   // Avalanche
   AVALANCHE = 43114,
   AVALANCHE_FUJI_TESTNET = 43113,
+  //Moonbeam
+  MOONBASE_ALPHA = 1287,
+  MOONRIVER = 1285,
 }
 
 const networkIDtoEndpoints: NetworkMap = {
@@ -121,6 +124,14 @@ const networkIDtoEndpoints: NetworkMap = {
   [NetworkID.AVALANCHE_FUJI_TESTNET]: {
     apiURL: "https://api-testnet.snowtrace.io/api",
     browserURL: "https://testnet.snowtrace.io/",
+  },
+  [NetworkID.MOONBASE_ALPHA]: {
+    apiURL: "https://api-moonbase.moonscan.io/api",
+    browserURL: "https://moonbase.moonscan.io/",
+  },
+  [NetworkID.MOONRIVER]: {
+    apiURL: "https://api-moonriver.moonscan.io/api",
+    browserURL: "https://moonriver.moonscan.io/",
   },
 };
 

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -43,7 +43,7 @@ enum NetworkID {
   // Avalanche
   AVALANCHE = 43114,
   AVALANCHE_FUJI_TESTNET = 43113,
-  //Moonbeam
+  // Moonbeam
   MOONBASE_ALPHA = 1287,
   MOONRIVER = 1285,
 }


### PR DESCRIPTION
<!-- Add a description of your PR here -->
This change adds support for Moonriver and Moonbase Alpha (testnet) contracts verification on [moonscan.io](https://moonriver.moonscan.io/), the Block explorer built by the Etherscan team for the Moonriver and Moonbase Alpha networks. 

Support for the Moonbeam network, which is not yet live, will be added in a future PR. 
