### PR TITLE
Configurable coinbase

### DIFF
--- a/.changeset/giant-candles-accept.md
+++ b/.changeset/giant-candles-accept.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Make the coinbase address customizable via a config field and a new RPC method.

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -360,6 +360,20 @@ await network.provider.send("hardhat_setCode", [
 
 This will result in account `0x0d20...000B` becoming a smart contract with bytecode `a1a2a3....` If that address was already a smart contract, then its code will be replaced by the specified one.
 
+#### `hardhat_setCoinbase`
+
+Sets the coinbase address to be used in new blocks.
+
+For example:
+
+```tsx
+await network.provider.send("hardhat_setCoinbase", [
+  "0x0d2026b3EE6eC71FC6746ADb6311F6d3Ba1C000B",
+]);
+```
+
+This will result in account `0x0d20...000B` being used as miner/coinbase in every new block.
+
 #### `hardhat_setLoggingEnabled`
 
 Enable or disable logging in Hardhat Network

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -60,6 +60,8 @@ You can set the following fields on the `hardhat` config:
 
 - `initialBaseFeePerGas`: The `baseFeePerGas` of the first block. Note that when forking a remote network, the "first block" is the one immediately after the block you forked from. This field must not be present if the `"hardfork"` is not `"london"` or a later one. Default value: `"1000000000"` if not forking. When forking a remote network, if the remote network uses EIP-1559, the first local block will use the right `baseFeePerGas` according to the EIP, otherwise `"10000000000"` is used.
 
+- `coinbase`: The address used as coinbase in new blocks. Default value: `"0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e"`.
+
 ### Mining modes
 
 You can configure the mining behavior under your Hardhat Network settings:

--- a/packages/hardhat-core/src/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-validation.ts
@@ -145,6 +145,27 @@ export const hexString = new t.Type<string>(
   t.identity
 );
 
+function isAddress(v: unknown): v is string {
+  if (typeof v !== "string") {
+    return false;
+  }
+
+  const trimmed = v.trim();
+
+  return (
+    trimmed.match(HEX_STRING_REGEX) !== null &&
+    trimmed.startsWith("0x") &&
+    trimmed.length === 42
+  );
+}
+
+export const address = new t.Type<string>(
+  "address",
+  isAddress,
+  (u, c) => (isAddress(u) ? t.success(u) : t.failure(u, c)),
+  t.identity
+);
+
 export const decimalString = new t.Type<string>(
   "decimal string",
   isDecimalString,
@@ -220,6 +241,7 @@ const HardhatNetworkConfig = t.type({
   loggingEnabled: optional(t.boolean),
   forking: optional(HardhatNetworkForkingConfig),
   mining: optional(HardhatNetworkMiningConfig),
+  coinbase: optional(address),
 });
 
 const HDAccountsConfig = t.type({

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -102,7 +102,8 @@ export function createProvider(
         : undefined,
       experimentalHardhatNetworkMessageTraceHooks,
       forkConfig,
-      paths !== undefined ? getForkCacheDirPath(paths) : undefined
+      paths !== undefined ? getForkCacheDirPath(paths) : undefined,
+      hardhatNetConfig.coinbase
     );
   } else {
     const HttpProvider = importProvider<

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
@@ -108,6 +108,9 @@ export class HardhatModule {
         return this._setNextBlockBaseFeePerGasAction(
           ...this._setNextBlockBaseFeePerGasParams(params)
         );
+
+      case "hardhat_setCoinbase":
+        return this._setCoinbaseAction(...this._setCoinbaseParams(params));
     }
 
     throw new MethodNotFoundError(`Method ${method} not found`);
@@ -343,6 +346,17 @@ export class HardhatModule {
     }
 
     this._node.setUserProvidedNextBlockBaseFeePerGas(baseFeePerGas);
+    return true;
+  }
+
+  // hardhat_setCoinbase
+
+  private _setCoinbaseParams(params: any[]): [Buffer] {
+    return validateParams(params, rpcAddress);
+  }
+
+  private async _setCoinbaseAction(address: Buffer) {
+    await this._node.setCoinbase(new Address(address));
     return true;
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -126,6 +126,7 @@ export interface Snapshot {
   nextBlockTimestamp: BN;
   irregularStatesByBlockNumber: Map<string, Buffer>;
   userProvidedNextBlockBaseFeePerGas: BN | undefined;
+  coinbase: string;
 }
 
 export type SendTransactionResult =

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -30,6 +30,7 @@ interface CommonConfig {
   tracingConfig?: TracingConfig;
   initialBaseFeePerGas?: number;
   mempoolOrder: MempoolOrder;
+  coinbase: string;
 }
 
 export type LocalNodeConfig = CommonConfig;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -116,10 +116,6 @@ const log = debug("hardhat:core:hardhat-network:node");
 
 const ethSigUtil = require("eth-sig-util");
 
-export const COINBASE_ADDRESS = Address.fromString(
-  "0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e"
-);
-
 /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
 
 export class HardhatNode extends EventEmitter {
@@ -245,6 +241,7 @@ export class HardhatNode extends EventEmitter {
       minGasPrice,
       initialBlockTimeOffset,
       mempoolOrder,
+      config.coinbase,
       genesisAccounts,
       tracingConfig,
       forkNetworkId,
@@ -319,6 +316,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     private _minGasPrice: BN,
     private _blockTimeOffsetSeconds: BN = new BN(0),
     private _mempoolOrder: MempoolOrder,
+    private _coinbase: string,
     genesisAccounts: GenesisAccount[],
     tracingConfig?: TracingConfig,
     private _forkNetworkId?: number,
@@ -701,7 +699,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
   }
 
   public getCoinbaseAddress(): Address {
-    return COINBASE_ADDRESS;
+    return Address.fromString(this._coinbase);
   }
 
   public async getStorageAt(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -872,6 +872,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       irregularStatesByBlockNumber: this._irregularStatesByBlockNumber,
       userProvidedNextBlockBaseFeePerGas:
         this.getUserProvidedNextBlockBaseFeePerGas(),
+      coinbase: this.getCoinbaseAddress().toString(),
     };
 
     this._irregularStatesByBlockNumber = new Map(
@@ -925,6 +926,8 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     } else {
       this._resetUserProvidedNextBlockBaseFeePerGas();
     }
+
+    this._coinbase = snapshot.coinbase;
 
     // We delete this and the following snapshots, as they can only be used
     // once in Ganache
@@ -1349,6 +1352,10 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       gasUsedRatio,
       reward: rewardPercentiles.length > 0 ? reward : undefined,
     };
+  }
+
+  public async setCoinbase(coinbase: Address) {
+    this._coinbase = coinbase.toString();
   }
 
   private _getGasUsedRatio(block: Block): number {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -55,6 +55,8 @@ const PRIVATE_RPC_METHODS = new Set([
 
 /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
 
+export const DEFAULT_COINBASE = "0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e";
+
 export class HardhatNetworkProvider
   extends EventEmitter
   implements EIP1193Provider
@@ -90,7 +92,8 @@ export class HardhatNetworkProvider
     private readonly _initialDate?: Date,
     private readonly _experimentalHardhatNetworkMessageTraceHooks: BoundExperimentalHardhatNetworkMessageTraceHook[] = [],
     private _forkConfig?: ForkConfig,
-    private readonly _forkCachePath?: string
+    private readonly _forkCachePath?: string,
+    private readonly _coinbase = DEFAULT_COINBASE
   ) {
     super();
   }
@@ -238,6 +241,7 @@ export class HardhatNetworkProvider
       forkConfig: this._forkConfig,
       forkCachePath:
         this._forkConfig !== undefined ? this._forkCachePath : undefined,
+      coinbase: this._coinbase,
     };
 
     const [common, node] = await HardhatNode.create(config);

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -44,6 +44,7 @@ export interface HardhatNetworkUserConfig {
   initialDate?: string;
   loggingEnabled?: boolean;
   forking?: HardhatNetworkForkingUserConfig;
+  coinbase?: string;
 }
 
 export type HardhatNetworkAccountsUserConfig =
@@ -120,6 +121,7 @@ export interface HardhatNetworkConfig {
   initialDate: string;
   loggingEnabled: boolean;
   forking?: HardhatNetworkForkingConfig;
+  coinbase?: string;
 }
 
 export type HardhatNetworkAccountsConfig =

--- a/packages/hardhat-core/test/fixture-projects/hardhat-network-with-custom-coinbase/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/hardhat-network-with-custom-coinbase/hardhat.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  networks: {
+    hardhat: {
+      coinbase: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+    },
+  },
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/internal/core/config/config-validation.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-validation.ts
@@ -1088,6 +1088,58 @@ describe("Config validation", function () {
             );
           });
         });
+
+        describe("Hardhat network's coinbase", function () {
+          it("Should fail if it's not a valid address", function () {
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      coinbase: "0x123",
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      coinbase: 123,
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectHardhatError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [HARDHAT_NETWORK_NAME]: {
+                      coinbase: "123",
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+          });
+
+          it("Should accept an optional address", function () {
+            assert.isEmpty(
+              getValidationErrors({
+                networks: {
+                  [HARDHAT_NETWORK_NAME]: {
+                    coinbase: "   0x0000000000000000000000000000000000000001  ",
+                  },
+                },
+              })
+            );
+          });
+        });
       });
 
       describe("HTTP network config", function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -51,6 +51,7 @@ export interface UseProviderOptions {
   allowUnlimitedContractSize?: boolean;
   initialBaseFeePerGas?: number;
   mempool?: HardhatNetworkMempoolConfig;
+  coinbase?: string;
 }
 
 export function useProvider({
@@ -67,6 +68,7 @@ export function useProvider({
   allowUnlimitedContractSize = DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
   initialBaseFeePerGas,
   mempool = DEFAULT_MEMPOOL_CONFIG,
+  coinbase,
 }: UseProviderOptions = {}) {
   beforeEach("Initialize provider", async function () {
     this.logger = new FakeModulesLogger(loggerEnabled);
@@ -89,7 +91,8 @@ export function useProvider({
       allowUnlimitedContractSize,
       undefined,
       undefined,
-      forkConfig
+      forkConfig,
+      coinbase
     );
     this.provider = new BackwardsCompatibilityProviderAdapter(
       this.hardhatNetworkProvider

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/hardhat-network-options.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/hardhat-network-options.ts
@@ -145,4 +145,29 @@ describe("Hardhat Network special options", function () {
       });
     });
   });
+
+  describe("coinbase", function () {
+    useFixtureProject("hardhat-network-with-custom-coinbase");
+    useEnvironment();
+
+    it("Should use the 0 address for the genesis block", async function () {
+      const block = await this.env.network.provider.send(
+        "eth_getBlockByNumber",
+        [numberToRpcQuantity(0), false]
+      );
+
+      assert.equal(block.miner, "0x0000000000000000000000000000000000000000");
+    });
+
+    it("Should use the coinbase address for the new blocks", async function () {
+      await this.env.network.provider.send("evm_mine");
+
+      const block = await this.env.network.provider.send(
+        "eth_getBlockByNumber",
+        [numberToRpcQuantity(1), false]
+      );
+
+      assert.equal(block.miner, this.env.config.networks.hardhat.coinbase);
+    });
+  });
 });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByHash.ts
@@ -1,6 +1,5 @@
 import { assert } from "chai";
 
-import { COINBASE_ADDRESS } from "../../../../../../../src/internal/hardhat-network/provider/node";
 import {
   RpcBlockOutput,
   RpcTransactionOutput,
@@ -11,6 +10,7 @@ import { setCWD } from "../../../../helpers/cwd";
 import { PROVIDERS } from "../../../../helpers/providers";
 import { retrieveForkBlockNumber } from "../../../../helpers/retrieveForkBlockNumber";
 import { sendTxToZeroAddress } from "../../../../helpers/transactions";
+import { DEFAULT_COINBASE } from "../../../../../../../src/internal/hardhat-network/provider/provider";
 
 describe("Eth module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
@@ -61,7 +61,7 @@ describe("Eth module", function () {
           assertQuantity(block.number, firstBlock + 1);
           assert.equal(block.transactions.length, 1);
           assert.include(block.transactions as string[], txHash);
-          assert.equal(block.miner, COINBASE_ADDRESS.toString());
+          assert.equal(block.miner, DEFAULT_COINBASE.toString());
           assert.isEmpty(block.uncles);
         });
 
@@ -81,7 +81,7 @@ describe("Eth module", function () {
           assert.equal(block.hash, txOutput.blockHash);
           assertQuantity(block.number, firstBlock + 1);
           assert.equal(block.transactions.length, 1);
-          assert.equal(block.miner, COINBASE_ADDRESS.toString());
+          assert.equal(block.miner, DEFAULT_COINBASE.toString());
           assert.deepEqual(
             block.transactions[0] as RpcTransactionOutput,
             txOutput

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
@@ -6,7 +6,6 @@ import {
   rpcQuantityToBN,
   rpcQuantityToNumber,
 } from "../../../../../../../src/internal/core/jsonrpc/types/base-types";
-import { COINBASE_ADDRESS } from "../../../../../../../src/internal/hardhat-network/provider/node";
 import {
   RpcBlockOutput,
   RpcTransactionOutput,
@@ -17,6 +16,7 @@ import { setCWD } from "../../../../helpers/cwd";
 import { PROVIDERS } from "../../../../helpers/providers";
 import { retrieveForkBlockNumber } from "../../../../helpers/retrieveForkBlockNumber";
 import { sendTxToZeroAddress } from "../../../../helpers/transactions";
+import { DEFAULT_COINBASE } from "../../../../../../../src/internal/hardhat-network/provider/provider";
 
 describe("Eth module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
@@ -84,7 +84,7 @@ describe("Eth module", function () {
           assert.equal(block.transactions.length, 1);
           assert.equal(block.parentHash, firstBlock.hash);
           assert.include(block.transactions as string[], txHash);
-          assert.equal(block.miner, COINBASE_ADDRESS.toString());
+          assert.equal(block.miner, DEFAULT_COINBASE.toString());
           assert.isEmpty(block.uncles);
         });
 
@@ -106,7 +106,7 @@ describe("Eth module", function () {
           assert.equal(block.transactions.length, 1);
           assert.equal(block.parentHash, firstBlock.hash);
           assert.include(block.transactions as string[], txHash);
-          assert.equal(block.miner, COINBASE_ADDRESS.toString());
+          assert.equal(block.miner, DEFAULT_COINBASE.toString());
           assert.isEmpty(block.uncles);
         });
 
@@ -127,7 +127,7 @@ describe("Eth module", function () {
           assertQuantity(block.number, firstBlockNumber + 1);
           assert.equal(block.transactions.length, 1);
           assert.equal(block.parentHash, firstBlock.hash);
-          assert.equal(block.miner, COINBASE_ADDRESS.toString());
+          assert.equal(block.miner, DEFAULT_COINBASE.toString());
           assert.isEmpty(block.uncles);
 
           const txOutput = block.transactions[0] as RpcTransactionOutput;

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
@@ -1,6 +1,5 @@
 import { assert } from "chai";
 
-import { COINBASE_ADDRESS } from "../../../../../../../src/internal/hardhat-network/provider/node";
 import { workaroundWindowsCiFailures } from "../../../../../../utils/workaround-windows-ci-failures";
 import {
   assertNotSupported,
@@ -11,6 +10,7 @@ import {
   DEFAULT_ACCOUNTS_ADDRESSES,
   PROVIDERS,
 } from "../../../../helpers/providers";
+import { DEFAULT_COINBASE } from "../../../../../../../src/internal/hardhat-network/provider/provider";
 
 /**
  * This file test the methods that are not covered by the other
@@ -43,10 +43,10 @@ describe("Eth module", function () {
       });
 
       describe("eth_coinbase", async function () {
-        it("should return the the hardcoded coinbase address", async function () {
+        it("should return the the default coinbase address", async function () {
           assert.equal(
             await this.provider.send("eth_coinbase"),
-            COINBASE_ADDRESS.toString()
+            DEFAULT_COINBASE
           );
         });
       });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
@@ -43,7 +43,7 @@ describe("Eth module", function () {
       });
 
       describe("eth_coinbase", async function () {
-        it("should return the the default coinbase address", async function () {
+        it("should return the default coinbase address", async function () {
           assert.equal(
             await this.provider.send("eth_coinbase"),
             DEFAULT_COINBASE

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -55,6 +55,7 @@ describe("HardhatNode", () => {
     genesisAccounts: DEFAULT_ACCOUNTS,
     initialBaseFeePerGas: 10,
     mempoolOrder: "priority",
+    coinbase: "0x0000000000000000000000000000000000000000",
   };
   const gasPrice = 20;
   let node: HardhatNode;
@@ -715,6 +716,7 @@ describe("HardhatNode", () => {
           minGasPrice: new BN(0),
           genesisAccounts: [],
           mempoolOrder: "priority",
+          coinbase: "0x0000000000000000000000000000000000000000",
         };
 
         const [common, forkedNode] = await HardhatNode.create(forkedNodeConfig);


### PR DESCRIPTION
This PR addresses #1918 by adding a new `coinbase` field to the Hardhat Network config and introducing a new `hardhat_setCoinbase` RPC method.