### PR TITLE
change: remove 0x from private key in tutorial

### DIFF
--- a/docs/tutorial/deploying-to-a-live-network.md
+++ b/docs/tutorial/deploying-to-a-live-network.md
@@ -69,7 +69,7 @@ module.exports = {
   networks: {
     ropsten: {
       url: `https://eth-ropsten.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
-      accounts: [`0x${ROPSTEN_PRIVATE_KEY}`]
+      accounts: [`${ROPSTEN_PRIVATE_KEY}`]
     }
   }
 };


### PR DESCRIPTION

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

<!-- Add a description of your PR here -->
During the deployment stage, Hardhat will throw an error saying `Invalid account: #0 for network: ropsten - private key too long, expected 32 bytes`.  I removed the `0x` string concatenation to make it easier for other people.