### PR TITLE
Update "building-plugins" doc to change example task signature

### DIFF
--- a/docs/advanced/building-plugins.md
+++ b/docs/advanced/building-plugins.md
@@ -31,7 +31,7 @@ extendEnvironment((hre) => {
   hre.hi = "Hello, Hardhat!";
 });
 
-task("envtest", (args, hre) => {
+task("envtest", async (args, hre) => {
   console.log(hre.hi);
 });
 


### PR DESCRIPTION
The `task` function expects an **async** action, this is now reflected in the docs building plugins guide (it has been updated in the cli sample projects previously).

## Preview

![image](https://user-images.githubusercontent.com/24030/143559696-a8aeee81-da9b-46b6-bca7-46385e73ce28.png)

The netlify preview:

https://deploy-preview-2100--nomiclabs-hardhat.netlify.app/advanced/building-plugins.html#extending-the-hardhat-runtime-environment