### PR TITLE
Fix recovering from malformed compiler list

### DIFF
--- a/.changeset/strange-rocks-poke.md
+++ b/.changeset/strange-rocks-poke.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a bug that prevented Hardhat from working if the compilers list was partially downloaded (issue #1466)

--- a/.changeset/wise-nails-lick.md
+++ b/.changeset/wise-nails-lick.md
@@ -2,4 +2,4 @@
 "@nomiclabs/hardhat-ethers": patch
 ---
 
-Adds a custom formatter to better display BigNumber's in Hardhat console (issue #2109).
+Adds a custom formatter to better display BigNumber's in Hardhat console (issue #2109)

--- a/packages/hardhat-core/src/internal/util/download.ts
+++ b/packages/hardhat-core/src/internal/util/download.ts
@@ -12,10 +12,9 @@ interface FetchOptions {
 const TEMP_FILE_PREFIX = "tmp-";
 
 function resolveTempFileName(filePath: string): string {
-  const { root, dir, ext, name } = path.parse(filePath);
+  const { dir, ext, name } = path.parse(filePath);
 
   return path.format({
-    root,
     dir,
     ext,
     name: `${TEMP_FILE_PREFIX}${name}`,

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -196,22 +196,36 @@ describe("Compiler downloader", function () {
 
   describe("Get compilers lists and CompilerBuild", function () {
     let compilersDir: string;
-    let downloadCalled: boolean;
+    let downloadCallCount: number;
+    let successDownloadTry: number;
     let mockDownloader: CompilerDownloader;
 
     beforeEach(async function () {
       compilersDir = this.tmpDir;
 
-      downloadCalled = false;
+      downloadCallCount = 0;
+      successDownloadTry = 0;
 
       mockDownloader = new CompilerDownloader(compilersDir, {
         download: async () => {
-          downloadCalled = true;
-          await saveMockCompilersList();
+          if (downloadCallCount >= successDownloadTry) {
+            await saveMockCompilersList();
+          } else {
+            await saveMalformedCompilersList();
+          }
+
+          downloadCallCount++;
         },
         forceSolcJs: true,
       });
     });
+
+    async function saveMalformedCompilersList() {
+      await fsExtra.outputFile(
+        path.join(compilersDir, CompilerPlatform.WASM, "list.json"),
+        "{ malformed"
+      );
+    }
 
     async function saveMockCompilersList() {
       await fsExtra.outputJSON(
@@ -228,7 +242,7 @@ describe("Compiler downloader", function () {
       describe("getCompilersList", function () {
         it("Doesn't download the list again", async function () {
           await mockDownloader.getCompilersList(CompilerPlatform.WASM);
-          assert.isFalse(downloadCalled);
+          assert.equal(downloadCallCount, 0);
         });
 
         it("Returns the right list", async function () {
@@ -243,7 +257,7 @@ describe("Compiler downloader", function () {
         describe("When the build is in the list", function () {
           it("Doesn't re-download the list", async function () {
             await mockDownloader.getCompilerBuild(localCompilerBuild.version);
-            assert.isFalse(downloadCalled);
+            assert.equal(downloadCallCount, 0);
           });
 
           it("Returns the right build", async function () {
@@ -258,8 +272,8 @@ describe("Compiler downloader", function () {
           it("Downloads the build", async function () {
             try {
               await mockDownloader.getCompilerBuild("non-existent");
-              assert.isTrue(downloadCalled);
-            } catch {
+              assert.equal(downloadCallCount, 1);
+            } catch (e) {
               // We ignore the error here, see next test.
             }
           });
@@ -278,14 +292,76 @@ describe("Compiler downloader", function () {
       describe("getCompilersList", function () {
         it("Downloads the compilers list", async function () {
           await mockDownloader.getCompilersList(CompilerPlatform.WASM);
-          assert.isTrue(downloadCalled);
+          assert.equal(downloadCallCount, 1);
         });
       });
 
       describe("getCompilerBuild", function () {
         it("Downloads the compilers list", async function () {
           await mockDownloader.getCompilerBuild(localCompilerBuild.version);
-          assert.isTrue(downloadCalled);
+          assert.equal(downloadCallCount, 1);
+        });
+      });
+    });
+
+    describe("When there is but it is malformed", function () {
+      beforeEach(async function () {
+        await saveMalformedCompilersList();
+      });
+
+      describe("getCompilersList", function () {
+        it("Redownloads the compilers list", async function () {
+          await mockDownloader.getCompilersList(CompilerPlatform.WASM);
+          assert.equal(downloadCallCount, 1);
+        });
+      });
+
+      describe("getCompilerBuild", function () {
+        it("Redownloads the compilers list", async function () {
+          await mockDownloader.getCompilerBuild(localCompilerBuild.version);
+          assert.equal(downloadCallCount, 1);
+        });
+      });
+    });
+
+    describe("When downloading fails", function () {
+      describe("getCompilersList", function () {
+        it("retries on a failed download", async function () {
+          successDownloadTry = 1;
+
+          await mockDownloader.getCompilersList(CompilerPlatform.WASM);
+          assert.equal(downloadCallCount, 2);
+        });
+
+        it("errors on too many failed downloads", async function () {
+          successDownloadTry = 999;
+
+          await assert.isRejected(
+            mockDownloader.getCompilersList(CompilerPlatform.WASM),
+            SyntaxError
+          );
+
+          assert.equal(downloadCallCount, 4);
+        });
+      });
+
+      describe("getCompilerBuild", function () {
+        it("retries on a failed download", async function () {
+          successDownloadTry = 1;
+
+          await mockDownloader.getCompilerBuild(localCompilerBuild.version);
+          assert.equal(downloadCallCount, 2);
+        });
+
+        it("errors on too many failed downloads", async function () {
+          successDownloadTry = 999;
+
+          await assert.isRejected(
+            mockDownloader.getCompilersList(CompilerPlatform.WASM),
+            SyntaxError
+          );
+
+          assert.equal(downloadCallCount, 4);
         });
       });
     });


### PR DESCRIPTION
This PR is an attempt to deal with #1466 

A halt during compiler download can lead the compiler list file to be partially written (and so invalid json). On a subsequent run the parsing of the compiler list fails and leaves the hardhat install in a broken state (requiring a `npx hardhat clean --global`).

This PR changes the compiler downloader behaviour to parse the file and on `SyntaxError`, redownload and retry the parse once more. Other errors that are not syntax based are rethrown.

## Manual testing

Additional tests have been added to the test suite, but if you are attempting to reproduce the bug manually:

1. create a new hardhat project based on the basic template
2. Start `npx hardhat node`
3. Run the sample deploy script `npx hardhat run ./scripts/sample-script.js --network localhost` triggering a compile (and compiler download)
4. Edit the `/Users/<user-name>/Library/Caches/hardhat-nodejs/compilers/macosx-amd64/list.json` file to be a partial and invalid json file, so deleting half of it for instance
5. Edit the `contracts/Greeter.sol` to force recompile on next deploy
6. Rerun the sample deploy script `npx hardhat run ./scripts/sample-script.js --network localhost`

That gives the expected error:

```shell
An unexpected error occurred:

SyntaxError: /Users/<user-name>/Library/Caches/hardhat-nodejs/compilers/macosx-amd64/list.json: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at /Users/<user-name>/projects/sandbox/another/node_modules/jsonfile/index.js:33:18
    at /Users/<user-name>/projects/sandbox/another/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:71:3)
```

With the fixes in this branch the second run of the deploy script will succeed, as it overwrites the compilers list json file on detecting it if malformed.

