### PR TITLE
Only log ansi escape characters when writing to terminal

### DIFF
--- a/.changeset/odd-trees-accept.md
+++ b/.changeset/odd-trees-accept.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+A fix to remove ansi escape characters when logging from hardhat node to file.

--- a/.changeset/odd-trees-accept.md
+++ b/.changeset/odd-trees-accept.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-A fix to remove ansi escape characters when logging from hardhat node to file.
+A fix to remove ansi escape characters when logging from hardhat node to file (issue #467).

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
@@ -35,15 +35,19 @@ function printLine(line: string) {
 }
 
 function replaceLastLine(newLine: string) {
-  process.stdout.write(
-    // eslint-disable-next-line prefer-template
-    ansiEscapes.cursorHide +
-      ansiEscapes.cursorPrevLine +
-      newLine +
-      ansiEscapes.eraseEndLine +
-      "\n" +
-      ansiEscapes.cursorShow
-  );
+  if (process.stdout.isTTY === true) {
+    process.stdout.write(
+      // eslint-disable-next-line prefer-template
+      ansiEscapes.cursorHide +
+        ansiEscapes.cursorPrevLine +
+        newLine +
+        ansiEscapes.eraseEndLine +
+        "\n" +
+        ansiEscapes.cursorShow
+    );
+  } else {
+    process.stdout.write(`${newLine}\n`);
+  }
 }
 
 /**


### PR DESCRIPTION
In the context of a file we should not include the escape codes while logging, but instead write raw text.

Relates to #467

## Manual Testing

This PR has been tested on MacOS.

To reproduce the issue:

```shell
hh node > log.txt

# In a separate terminal run

curl -H "Content-Type: application/json" -X POST --data \
        '{"id":1337,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}' \
        http://localhost:8545

curl -H "Content-Type: application/json" -X POST --data \
        '{"id":1337,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}' \
        http://localhost:8545

curl -H "Content-Type: application/json" -X POST --data \
        '{"id":1337,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}' \
        http://localhost:8545

# open the log.txt file in your preferred editor and scroll to the bottom
vim log.txt

# ...
# Account #19: 0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199 (10000 ETH)
# Private Key: 0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e
# 
# WARNING: These accounts, and their private keys, are publicly known.
# Any funds sent to them on Mainnet or any other live network WILL BE LOST.

# eth_blockNumber
# ^[[?25l^[[Feth_blockNumber (2)^[[K
# ^[[?25h^[[?25l^[[Feth_blockNumber (3)^[[K
# ^[[?25h
```

The overwrite and color codes are appearing in the log file. With this PR applied the bottom of the log should be:

```
eth_blockNumber
eth_blockNumber (2)
eth_blockNumber (3)
```

Repeating the same in the terminal i.e. `hh node` without piping to file. Should give:
![image](https://user-images.githubusercontent.com/24030/143902750-c908cd66-2dad-40f8-8737-4ab864985ac6.png)


