### PR TITLE
Add custom formatter for BigNumber's in console

### DIFF
--- a/.changeset/wise-nails-lick.md
+++ b/.changeset/wise-nails-lick.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-ethers": patch
+---
+
+Adds a custom formatter to better display BigNumber's in Hardhat console (issue #2109).

--- a/packages/hardhat-ethers/src/internal/index.ts
+++ b/packages/hardhat-ethers/src/internal/index.ts
@@ -11,12 +11,22 @@ import {
 import type * as ProviderProxyT from "./provider-proxy";
 import "./type-extensions";
 
+const registerCustomInspection = (BigNumber: any) => {
+  const inspectCustomSymbol = Symbol.for("nodejs.util.inspect.custom");
+
+  BigNumber.prototype[inspectCustomSymbol] = function () {
+    return `BigNumber { value: "${this.toString()}" }`;
+  };
+};
+
 extendEnvironment((hre) => {
   hre.ethers = lazyObject(() => {
     const { createProviderProxy } =
       require("./provider-proxy") as typeof ProviderProxyT;
 
     const { ethers } = require("ethers") as typeof EthersT;
+
+    registerCustomInspection(ethers.BigNumber);
 
     const providerProxy = createProviderProxy(hre.network.provider);
 

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import { ethers } from "ethers";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { Artifact } from "hardhat/types";
+import util from "util";
 
 import { EthersProviderWrapper } from "../src/internal/ethers-provider-wrapper";
 
@@ -20,6 +21,84 @@ describe("Ethers plugin", function () {
           "getContractAt",
           ...Object.keys(ethers),
         ]);
+      });
+
+      describe("Custom formatters", function () {
+        const assertBigNumberFormat = function (
+          BigNumber: any,
+          value: string | number,
+          expected: string
+        ) {
+          assert.equal(util.format("%o", BigNumber.from(value)), expected);
+        };
+
+        describe("BigNumber", function () {
+          it("should format zero unaltered", function () {
+            assertBigNumberFormat(
+              this.env.ethers.BigNumber,
+              0,
+              'BigNumber { value: "0" }'
+            );
+          });
+
+          it("should provide human readable versions of positive integers", function () {
+            const BigNumber = this.env.ethers.BigNumber;
+
+            assertBigNumberFormat(BigNumber, 1, 'BigNumber { value: "1" }');
+            assertBigNumberFormat(BigNumber, 999, 'BigNumber { value: "999" }');
+            assertBigNumberFormat(
+              BigNumber,
+              1000,
+              'BigNumber { value: "1000" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              999999,
+              'BigNumber { value: "999999" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              1000000,
+              'BigNumber { value: "1000000" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              "999999999999999999292",
+              'BigNumber { value: "999999999999999999292" }'
+            );
+          });
+
+          it("should provide human readable versions of negative integers", function () {
+            const BigNumber = this.env.ethers.BigNumber;
+
+            assertBigNumberFormat(BigNumber, -1, 'BigNumber { value: "-1" }');
+            assertBigNumberFormat(
+              BigNumber,
+              -999,
+              'BigNumber { value: "-999" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              -1000,
+              'BigNumber { value: "-1000" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              -999999,
+              'BigNumber { value: "-999999" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              -1000000,
+              'BigNumber { value: "-1000000" }'
+            );
+            assertBigNumberFormat(
+              BigNumber,
+              "-999999999999999999292",
+              'BigNumber { value: "-999999999999999999292" }'
+            );
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Extends the BigNumber prototype provided by `hardhat-ethers` to include a formatter for node inspection tools. Large BigNumbers that are inspected in hardhat console will now display with commas to help readability.

The formatter uses `,` for readability in large BigNumbers:

```
1
1,000
999,999,999
```

Relates to #2109.

## Preview

![image](https://user-images.githubusercontent.com/24030/144042366-566ecff5-ea68-4701-87a8-b6bc36d902bb.png)

## Manual Testing

To test manually, build the `hardhat-ethers` plugin locally and link (see `CONTRIBUTION.md`) the plugin to a local hardhat project. From that project run hardhat console (i.e. `hh console`), you should then be able to see the newly formatted BigNumbers:

```shell
> ethers.BigNumber.from(999999999999789)
999,999,999,999,789
```
