### PR TITLE
Add artifact functions in ethers `getContractFactoryFromArtifact` and `getContractAtFromArtifact`

### DIFF
--- a/.changeset/smooth-worms-end.md
+++ b/.changeset/smooth-worms-end.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-ethers": patch
+---
+
+Add equivalents in hardhat-ethers for `getContractFactory` and `getContractAt` that support passing `Artifact`, specifically `getContractFactoryFromArtifact` and `getContractAtFromArtifact` (issue #1716)

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -60,8 +60,11 @@ function getContractFactory(name: string, signer: ethers.Signer): Promise<ethers
 
 function getContractFactory(name: string, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
 
+function getContractFactoryFromArtifact(artifact: Artifact, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
 
 function getContractAt(nameOrAbi: string | any[], address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
+
+function getContractAtFromArtifact(artifact: Artifact, address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
 
 function getSigners() => Promise<ethers.Signer[]>;
 

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -60,11 +60,27 @@ function getContractFactory(name: string, signer: ethers.Signer): Promise<ethers
 
 function getContractFactory(name: string, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
 
-function getContractFactoryFromArtifact(artifact: Artifact, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
+function getContractFactory(abi: any[], bytecode: ethers.utils.BytesLike): Promise<ethers.ContractFactory>;
 
-function getContractAt(nameOrAbi: string | any[], address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
+function getContractFactory(abi: any[], bytecode: ethers.utils.BytesLike, signer: ethers.Signer): Promise<ethers.ContractFactory>;
 
-function getContractAtFromArtifact(artifact: Artifact, address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
+function getContractFactoryFromArtifact(artifact: Artifact): Promise<ethers.ContractFactory>;
+
+function getContractFactoryFromArtifact(artifact: Artifact, signer: ethers.Signer): Promise<ethers.ContractFactory>;
+
+function getContractFactoryFromArtifact(artifact: Artifact, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
+
+function getContractAt(name: string, address: string): Promise<ethers.Contract>;
+
+function getContractAt(name: string, address: string, signer: ethers.Signer): Promise<ethers.Contract>;
+
+function getContractAt(abi: any[], address: string): Promise<ethers.Contract>;
+
+function getContractAt(abi: any[], address: string, signer: ethers.Signer): Promise<ethers.Contract>;
+
+function getContractAtFromArtifact(artifact: Artifact, address: string): Promise<ethers.Contract>;
+
+function getContractAtFromArtifact(artifact: Artifact, address: string, signer: ethers.Signer): Promise<ethers.Contract>;
 
 function getSigners() => Promise<ethers.Signer[]>;
 

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -54,37 +54,25 @@ interface FactoryOptions {
   libraries?: Libraries;
 }
 
-function getContractFactory(name: string): Promise<ethers.ContractFactory>;
-
-function getContractFactory(name: string, signer: ethers.Signer): Promise<ethers.ContractFactory>;
+function getContractFactory(name: string, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
 
 function getContractFactory(name: string, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
 
-function getContractFactory(abi: any[], bytecode: ethers.utils.BytesLike): Promise<ethers.ContractFactory>;
+function getContractFactory(abi: any[], bytecode: ethers.utils.BytesLike, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
 
-function getContractFactory(abi: any[], bytecode: ethers.utils.BytesLike, signer: ethers.Signer): Promise<ethers.ContractFactory>;
+function getContractAt(name: string, address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
 
-function getContractFactoryFromArtifact(artifact: Artifact): Promise<ethers.ContractFactory>;
-
-function getContractFactoryFromArtifact(artifact: Artifact, signer: ethers.Signer): Promise<ethers.ContractFactory>;
-
-function getContractFactoryFromArtifact(artifact: Artifact, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
-
-function getContractAt(name: string, address: string): Promise<ethers.Contract>;
-
-function getContractAt(name: string, address: string, signer: ethers.Signer): Promise<ethers.Contract>;
-
-function getContractAt(abi: any[], address: string): Promise<ethers.Contract>;
-
-function getContractAt(abi: any[], address: string, signer: ethers.Signer): Promise<ethers.Contract>;
-
-function getContractAtFromArtifact(artifact: Artifact, address: string): Promise<ethers.Contract>;
-
-function getContractAtFromArtifact(artifact: Artifact, address: string, signer: ethers.Signer): Promise<ethers.Contract>;
+function getContractAt(abi: any[], address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
 
 function getSigners() => Promise<ethers.Signer[]>;
 
 function getSigner(address: string) => Promise<ethers.Signer>;
+
+function getContractFactoryFromArtifact(artifact: Artifact, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
+
+function getContractFactoryFromArtifact(artifact: Artifact, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
+
+function getContractAtFromArtifact(artifact: Artifact, address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
 ```
 
 The [`Contract`s](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contract/) and [`ContractFactory`s](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contract-factory/) returned by these helpers are connected to the first [signer](https://docs.ethers.io/v5/single-page/#/v5/api/signer/) returned by `getSigners` by default.

--- a/packages/hardhat-ethers/src/internal/index.ts
+++ b/packages/hardhat-ethers/src/internal/index.ts
@@ -4,7 +4,9 @@ import { lazyObject } from "hardhat/plugins";
 
 import {
   getContractAt,
+  getContractAtFromArtifact,
   getContractFactory,
+  getContractFactoryFromArtifact,
   getSigner,
   getSigners,
 } from "./helpers";
@@ -42,7 +44,12 @@ extendEnvironment((hre) => {
       // We cast to any here as we hit a limitation of Function#bind and
       // overloads. See: https://github.com/microsoft/TypeScript/issues/28582
       getContractFactory: getContractFactory.bind(null, hre) as any,
+      getContractFactoryFromArtifact: getContractFactoryFromArtifact.bind(
+        null,
+        hre
+      ),
       getContractAt: getContractAt.bind(null, hre),
+      getContractAtFromArtifact: getContractAtFromArtifact.bind(null, hre),
     };
   });
 });

--- a/packages/hardhat-ethers/src/types/index.ts
+++ b/packages/hardhat-ethers/src/types/index.ts
@@ -1,4 +1,5 @@
 import type * as ethers from "ethers";
+import { Artifact } from "hardhat/src/types";
 
 import type { SignerWithAddress } from "../signers";
 
@@ -25,8 +26,17 @@ export interface HardhatEthersHelpers {
   provider: ethers.providers.JsonRpcProvider;
 
   getContractFactory: typeof getContractFactory;
+  getContractFactoryFromArtifact: (
+    artifact: Artifact,
+    signerOrOptions?: ethers.Signer | FactoryOptions
+  ) => Promise<ethers.ContractFactory>;
   getContractAt: (
     nameOrAbi: string | any[],
+    address: string,
+    signer?: ethers.Signer
+  ) => Promise<ethers.Contract>;
+  getContractAtFromArtifact: (
+    artifact: Artifact,
     address: string,
     signer?: ethers.Signer
   ) => Promise<ethers.Contract>;


### PR DESCRIPTION
In `hardhat-ethers`, allow passing of artifacts (resolved via custom code) into an equivalent of the `getContractFactory` call, this is instead of resolving by contract name.

The intention here is to support custom contract artifact resolution but still allow the leveraging of `hardhat-ethers`.

Two new functions have been added to support this without altering the existing signature:

* getContractFactoryFromArtifact
* getContractAtFromArtifact

Relates to #1716

## Example Usage

```typescript
import { ethers } from "hardhat";
import { Artifacts } from "hardhat/internal/artifacts";
import { Artifact } from "hardhat/types";

export async function getArtifact(contract: string): Promise<Artifact> {
  const artifactsPath: string = "./artifacts";

  const artifacts = new Artifacts(artifactsPath);
  return artifacts.readArtifact(contract);
}

async function main() {
  const artifact = await getArtifact("Greeter");

  const Factory = await ethers.getContractFactoryFromArtifact(artifact);

  const greeter = await Factory.deploy("Hello, Hardhat!");

  await greeter.deployed();

  console.log("Greeter deployed to:", greeter.address);

  const response = await greeter.greet();

  console.log("First Response", response);

  const alternateGreeter = await ethers.getContractAtFromArtifact(
    artifact,
    greeter.address
  );

  const secondResponse = await alternateGreeter.greet();

  console.log("Second Response", secondResponse);
}

// We recommend this pattern to be able to use async/await everywhere
// and properly handle errors.
main().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
```

## TODO

* [x] support artifact in signature of `getContractFactoryFromArtifact`
* [x] support artifact in signature of `getContractAtFromArtifact`
* [x] resolve type issue in consuming lib
* [x] determine and update any docs affected