### PR TITLE
Support multiple api keys

### DIFF
--- a/.changeset/thin-terms-confess.md
+++ b/.changeset/thin-terms-confess.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": major
+---
+
+Support multiple api keys in `hardhat-etherscan` to allow for verification against multiple networks (issue #1448)

--- a/packages/hardhat-etherscan/CONTRIBUTING.md
+++ b/packages/hardhat-etherscan/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Hardhat Etherscan
+
+The `hardhat-etherscan` plugin works with any explorer that is powered by Etherscan or that has a compatible verification API. This guide explains how to send a Pull Request that adds support for a new chain.
+
+1. Update [types.ts](./src/types.ts) to include the new chain:
+   - Add the chain as an entry in the `Chains` enum, ensuring the name and string value match.
+2. Update [ChainConfig](./src/ChainConfig.ts) with the parameters for the chain you want to add:
+
+   - Add an entry to the `chainConfig` object under the name you added to the `Chains` enum
+   - Under that `chainConfig` entry add the chain id. For example, if your network is called "foo_chain" and its chain id is 1234, you need to add:
+
+     ```jsx
+     foo_chain: {
+       chainId: 1234,
+       ...
+     },
+     ```
+
+   - Add the proper URLs under the `chainConfig` chain entry. For example:
+
+     ```jsx
+     foo_chain: {
+       chainId: 1234,
+       urls: {
+         apiURL: "https://api.foochainscan.io/api",
+         browserURL: "https://foochainscan.io",
+       },
+     },
+     ```
+
+     Here `apiURL` is the endpoint that corresponds to the API of the explorer, which will be used to send the verification request. `browserURL` is the URL of the explorer, that will be used to show a link after a successful verification. For this example, you would see a message with something like: `https://foochainscan.io/address/0xabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde#code`
+
+3. Send a pull request with these changes.
+4. As part of the PR, and for each chain you are adding:
+   - Indicate a public JSON-RPC endpoint that can be used for that chain.
+   - Send some funds to this address: `0x4444c3F7D7d3153Dc0773C31ae10cf9B5495d4Bb`. These will be used by us to check that a contract can be deployed and verified with these changes. Don't send too much value, just enough to deploy a simple contract.

--- a/packages/hardhat-etherscan/CONTRIBUTING.md
+++ b/packages/hardhat-etherscan/CONTRIBUTING.md
@@ -3,14 +3,14 @@
 The `hardhat-etherscan` plugin works with any explorer that is powered by Etherscan or that has a compatible verification API. This guide explains how to send a Pull Request that adds support for a new chain.
 
 1. Update [types.ts](./src/types.ts) to include the new chain:
-   - Add the chain as an entry in the `Chains` enum, ensuring the name and string value match.
+   - Add the chain as a new value in the `Chain` type.
 2. Update [ChainConfig](./src/ChainConfig.ts) with the parameters for the chain you want to add:
 
-   - Add an entry to the `chainConfig` object under the name you added to the `Chains` enum
-   - Under that `chainConfig` entry add the chain id. For example, if your network is called "foo_chain" and its chain id is 1234, you need to add:
+   - Add an entry to the `chainConfig` object under the name you added to the `Chain` type
+   - Under that `chainConfig` entry add the chain id. For example, if your network is called "fooChain" and its chain id is 1234, you need to add:
 
      ```jsx
-     foo_chain: {
+     fooChain: {
        chainId: 1234,
        ...
      },
@@ -19,7 +19,7 @@ The `hardhat-etherscan` plugin works with any explorer that is powered by Ethers
    - Add the proper URLs under the `chainConfig` chain entry. For example:
 
      ```jsx
-     foo_chain: {
+     fooChain: {
        chainId: 1234,
        urls: {
          apiURL: "https://api.foochainscan.io/api",
@@ -30,7 +30,8 @@ The `hardhat-etherscan` plugin works with any explorer that is powered by Ethers
 
      Here `apiURL` is the endpoint that corresponds to the API of the explorer, which will be used to send the verification request. `browserURL` is the URL of the explorer, that will be used to show a link after a successful verification. For this example, you would see a message with something like: `https://foochainscan.io/address/0xabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde#code`
 
-3. Send a pull request with these changes.
-4. As part of the PR, and for each chain you are adding:
+3. Update the snippet in the [`Multiple API keys...`](./README.md#multiple-api-keys-and-alternative-block-explorers) section of the README to include the added chain.
+4. Send a pull request with these changes.
+5. As part of the PR, and for each chain you are adding:
    - Indicate a public JSON-RPC endpoint that can be used for that chain.
    - Send some funds to this address: `0x4444c3F7D7d3153Dc0773C31ae10cf9B5495d4Bb`. These will be used by us to check that a contract can be deployed and verified with these changes. Don't send too much value, just enough to deploy a simple contract.

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -124,11 +124,9 @@ module.exports = {
 
 ### Multiple API keys and alternative block explorers
 
-If your project targets multiple evm sidechains, you many need to verify using the block explorers particular to those chains, and so need to set multiple API keys.
+If your project targets multiple EVM-compatible networks that have different explorers, you'll need to set multiple API keys.
 
-A block explorer API key can be set per chain, hardhat will use the `chainId` of the specified network to determine which block explorer and API key to use.
-
-To configure the API keys for the chains you are using, provide an object with under `etherscan/apiKey` with properties matching the chain:
+To configure the API keys for the chains you are using, provide an object under `etherscan/apiKey` with the identifier of each chain as the key. **This is not necessarily the same name that you are using to define the network**. The snippet below shows the values you should use for each chain:
 
 ```js
 module.exports = {

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -145,28 +145,28 @@ module.exports = {
         kovan: "YOUR_ETHERSCAN_API_KEY",
         // binance smart chain
         bsc = "YOUR_BSCSCAN_API_KEY",
-        bsc_testnet = "YOUR_BSCSCAN_API_KEY",
+        bscTestnet = "YOUR_BSCSCAN_API_KEY",
         // huobi eco chain
         heco = "YOUR_HECOINFO_API_KEY",
-        heco_testnet = "YOUR_HECOINFO_API_KEY",
+        hecoTestnet = "YOUR_HECOINFO_API_KEY",
         // fantom mainnet
         opera = "YOUR_FTMSCAN_API_KEY",
-        ftm_testnet = "YOUR_FTMSCAN_API_KEY",
+        ftmTestnet = "YOUR_FTMSCAN_API_KEY",
         // optimistim
-        optimistic_ethereum = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
-        optimistic_kovan = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
+        optimisticEthereum = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
+        optimisticKovan = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
         // polygon
         polygon = "YOUR_POLYGONSCAN_API_KEY",
-        polygon_mumbai = "YOUR_POLYGONSCAN_API_KEY",
+        polygonMumbai = "YOUR_POLYGONSCAN_API_KEY",
         // arbitrum
-        arbitrum_one = "YOUR_ARBISCAN_API_KEY",
-        arbitrum_testnet = "YOUR_ARBISCAN_API_KEY",
+        arbitrumOne = "YOUR_ARBISCAN_API_KEY",
+        arbitrumTestnet = "YOUR_ARBISCAN_API_KEY",
         // avalanche
         avalanche = "YOUR_SNOWTRACE_API_KEY",
-        avalanche_fuji_testnet = "YOUR_SNOWTRACE_API_KEY",
+        avalancheFujiTestnet = "YOUR_SNOWTRACE_API_KEY",
         // moonriver
         moonriver = "YOUR_MOONRIVER_MOONSCAN_API_KEY",
-        moonbase_alpha = "YOUR_MOONRIVER_MOONSCAN_API_KEY",
+        moonbaseAlpha = "YOUR_MOONRIVER_MOONSCAN_API_KEY",
     }
   }
 };

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -58,6 +58,8 @@ module.exports = {
 };
 ```
 
+Alternatively you can specify more than one block explorer API key, by passing an object under the `apiKey` property, see [`Multiple API keys and alternative block explorers`](#multiple-api-keys-and-alternative-block-explorers).
+
 Lastly, run the `verify` task, passing the address of the contract, the network where it's deployed, and the constructor arguments that were used to deploy it (if any):
 
 ```bash
@@ -120,6 +122,56 @@ module.exports = {
 };
 ```
 
+### Multiple API keys and alternative block explorers
+
+If your project targets multiple evm sidechains, you many need to verify using the block explorers particular to those chains, and so need to set multiple API keys.
+
+A block explorer API key can be set per chain, hardhat will use the `chainId` of the specified network to determine which block explorer and API key to use.
+
+To configure the API keys for the chains you are using, provide an object with under `etherscan/apiKey` with properties matching the chain:
+
+```js
+module.exports = {
+  networks: {
+    mainnet: { ... },
+    testnet: { ... }
+  },
+  etherscan: {
+    apiKey: {
+        mainnet: "YOUR_ETHERSCAN_API_KEY",
+        ropsten: "YOUR_ETHERSCAN_API_KEY",
+        rinkeby: "YOUR_ETHERSCAN_API_KEY",
+        goerli: "YOUR_ETHERSCAN_API_KEY",
+        kovan: "YOUR_ETHERSCAN_API_KEY",
+        // binance smart chain
+        bsc = "YOUR_BSCSCAN_API_KEY",
+        bsc_testnet = "YOUR_BSCSCAN_API_KEY",
+        // huobi eco chain
+        heco = "YOUR_HECOINFO_API_KEY",
+        heco_testnet = "YOUR_HECOINFO_API_KEY",
+        // fantom mainnet
+        opera = "YOUR_FTMSCAN_API_KEY",
+        ftm_testnet = "YOUR_FTMSCAN_API_KEY",
+        // optimistim
+        optimistic_ethereum = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
+        optimistic_kovan = "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
+        // polygon
+        polygon = "YOUR_POLYGONSCAN_API_KEY",
+        polygon_mumbai = "YOUR_POLYGONSCAN_API_KEY",
+        // arbitrum
+        arbitrum_one = "YOUR_ARBISCAN_API_KEY",
+        arbitrum_testnet = "YOUR_ARBISCAN_API_KEY",
+        // avalanche
+        avalanche = "YOUR_SNOWTRACE_API_KEY",
+        avalanche_fuji_testnet = "YOUR_SNOWTRACE_API_KEY",
+        // moonriver
+        moonriver = "YOUR_MOONRIVER_MOONSCAN_API_KEY",
+        moonbase_alpha = "YOUR_MOONRIVER_MOONSCAN_API_KEY",
+    }
+  }
+};
+```
+
 ### Using programmatically
 
 To call the verification task from within a Hardhat task or script, use the `"verify:verify"` subtask. Assuming the same contract as [above](#complex-arguments), you can run the subtask like this:
@@ -161,3 +213,7 @@ The plugin works by fetching the bytecode in the given address and using it to c
 ## Known limitations
 
 - Adding, removing, moving or renaming new contracts to the hardhat project or reorganizing the directory structure of contracts after deployment may alter the resulting bytecode in some solc versions. See this [Solidity issue](https://github.com/ethereum/solidity/issues/9573) for further information.
+
+## Contributing
+
+See the [Contribution Guide](./CONTRIBUTING.md) for details.

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -1,0 +1,152 @@
+import { ChainConfig } from "./types";
+
+// See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
+export const chainConfig: ChainConfig = {
+  mainnet: {
+    chainId: 1,
+    urls: {
+      apiURL: "https://api.etherscan.io/api",
+      browserURL: "https://etherscan.io",
+    },
+  },
+  ropsten: {
+    chainId: 3,
+    urls: {
+      apiURL: "https://api-ropsten.etherscan.io/api",
+      browserURL: "https://ropsten.etherscan.io",
+    },
+  },
+  rinkeby: {
+    chainId: 4,
+    urls: {
+      apiURL: "https://api-rinkeby.etherscan.io/api",
+      browserURL: "https://rinkeby.etherscan.io",
+    },
+  },
+  goerli: {
+    chainId: 5,
+    urls: {
+      apiURL: "https://api-goerli.etherscan.io/api",
+      browserURL: "https://goerli.etherscan.io",
+    },
+  },
+  kovan: {
+    chainId: 42,
+    urls: {
+      apiURL: "https://api-kovan.etherscan.io/api",
+      browserURL: "https://kovan.etherscan.io",
+    },
+  },
+  bsc: {
+    chainId: 56,
+    urls: {
+      apiURL: "https://api.bscscan.com/api",
+      browserURL: "https://bscscan.com",
+    },
+  },
+  bsc_testnet: {
+    chainId: 97,
+    urls: {
+      apiURL: "https://api-testnet.bscscan.com/api",
+      browserURL: "https://testnet.bscscan.com",
+    },
+  },
+  heco: {
+    chainId: 128,
+    urls: {
+      apiURL: "https://api.hecoinfo.com/api",
+      browserURL: "https://hecoinfo.com",
+    },
+  },
+  heco_testnet: {
+    chainId: 256,
+    urls: {
+      apiURL: "https://api-testnet.hecoinfo.com/api",
+      browserURL: "https://testnet.hecoinfo.com",
+    },
+  },
+  opera: {
+    chainId: 250,
+    urls: {
+      apiURL: "https://api.ftmscan.com/api",
+      browserURL: "https://ftmscan.com",
+    },
+  },
+  ftm_testnet: {
+    chainId: 4002,
+    urls: {
+      apiURL: "https://api-testnet.ftmscan.com/api",
+      browserURL: "https://testnet.ftmscan.com",
+    },
+  },
+  optimistic_ethereum: {
+    chainId: 10,
+    urls: {
+      apiURL: "https://api-optimistic.etherscan.io/api",
+      browserURL: "https://optimistic.etherscan.io/",
+    },
+  },
+  optimistic_kovan: {
+    chainId: 69,
+    urls: {
+      apiURL: "https://api-kovan-optimistic.etherscan.io/api",
+      browserURL: "https://kovan-optimistic.etherscan.io/",
+    },
+  },
+  polygon: {
+    chainId: 137,
+    urls: {
+      apiURL: "https://api.polygonscan.com/api",
+      browserURL: "https://polygonscan.com",
+    },
+  },
+  polygon_mumbai: {
+    chainId: 80001,
+    urls: {
+      apiURL: "https://api-testnet.polygonscan.com/api",
+      browserURL: "https://mumbai.polygonscan.com/",
+    },
+  },
+  arbitrum_one: {
+    chainId: 42161,
+    urls: {
+      apiURL: "https://api.arbiscan.io/api",
+      browserURL: "https://arbiscan.io/",
+    },
+  },
+  arbitrum_testnet: {
+    chainId: 421611,
+    urls: {
+      apiURL: "https://api-testnet.arbiscan.io/api",
+      browserURL: "https://testnet.arbiscan.io/",
+    },
+  },
+  avalanche: {
+    chainId: 43114,
+    urls: {
+      apiURL: "https://api.snowtrace.io/api",
+      browserURL: "https://snowtrace.io/",
+    },
+  },
+  avalanche_fuji_testnet: {
+    chainId: 43113,
+    urls: {
+      apiURL: "https://api-testnet.snowtrace.io/api",
+      browserURL: "https://testnet.snowtrace.io/",
+    },
+  },
+  moonriver: {
+    chainId: 1285,
+    urls: {
+      apiURL: "https://api-moonriver.moonscan.io/api",
+      browserURL: "https://moonscan.io",
+    },
+  },
+  moonbase_alpha: {
+    chainId: 1287,
+    urls: {
+      apiURL: "https://api-moonbase.moonscan.io/api",
+      browserURL: "https://moonbase.moonscan.io/",
+    },
+  },
+};

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -44,7 +44,7 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://bscscan.com",
     },
   },
-  bsc_testnet: {
+  bscTestnet: {
     chainId: 97,
     urls: {
       apiURL: "https://api-testnet.bscscan.com/api",
@@ -58,7 +58,7 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://hecoinfo.com",
     },
   },
-  heco_testnet: {
+  hecoTestnet: {
     chainId: 256,
     urls: {
       apiURL: "https://api-testnet.hecoinfo.com/api",
@@ -72,21 +72,21 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://ftmscan.com",
     },
   },
-  ftm_testnet: {
+  ftmTestnet: {
     chainId: 4002,
     urls: {
       apiURL: "https://api-testnet.ftmscan.com/api",
       browserURL: "https://testnet.ftmscan.com",
     },
   },
-  optimistic_ethereum: {
+  optimisticEthereum: {
     chainId: 10,
     urls: {
       apiURL: "https://api-optimistic.etherscan.io/api",
       browserURL: "https://optimistic.etherscan.io/",
     },
   },
-  optimistic_kovan: {
+  optimisticKovan: {
     chainId: 69,
     urls: {
       apiURL: "https://api-kovan-optimistic.etherscan.io/api",
@@ -100,21 +100,21 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://polygonscan.com",
     },
   },
-  polygon_mumbai: {
+  polygonMumbai: {
     chainId: 80001,
     urls: {
       apiURL: "https://api-testnet.polygonscan.com/api",
       browserURL: "https://mumbai.polygonscan.com/",
     },
   },
-  arbitrum_one: {
+  arbitrumOne: {
     chainId: 42161,
     urls: {
       apiURL: "https://api.arbiscan.io/api",
       browserURL: "https://arbiscan.io/",
     },
   },
-  arbitrum_testnet: {
+  arbitrumTestnet: {
     chainId: 421611,
     urls: {
       apiURL: "https://api-testnet.arbiscan.io/api",
@@ -128,7 +128,7 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://snowtrace.io/",
     },
   },
-  avalanche_fuji_testnet: {
+  avalancheFujiTestnet: {
     chainId: 43113,
     urls: {
       apiURL: "https://api-testnet.snowtrace.io/api",
@@ -142,7 +142,7 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://moonscan.io",
     },
   },
-  moonbase_alpha: {
+  moonbaseAlpha: {
     chainId: 1287,
     urls: {
       apiURL: "https://api-moonbase.moonscan.io/api",

--- a/packages/hardhat-etherscan/src/config.ts
+++ b/packages/hardhat-etherscan/src/config.ts
@@ -33,7 +33,9 @@ export const etherscanConfigExtender: ConfigExtender = (
     if (unallowedChains.length > 0) {
       throw new NomicLabsHardhatPluginError(
         pluginName,
-        `Etherscan API token "${unallowedChains[0]}" is for an unsupported network`
+        `Etherscan API token "${unallowedChains[0]}" is for an unsupported network
+
+Learn more at https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html#multiple-api-keys-and-alternative-block-explorers`
       );
     }
 

--- a/packages/hardhat-etherscan/src/config.ts
+++ b/packages/hardhat-etherscan/src/config.ts
@@ -1,4 +1,23 @@
+import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { ConfigExtender } from "hardhat/types";
+import { chainConfig } from "./ChainConfig";
+import { EtherscanConfig } from "./types";
+import { pluginName } from "./constants";
+
+const verifyAllowedChains = (etherscanConfig: EtherscanConfig): string[] => {
+  if (
+    etherscanConfig.apiKey === null ||
+    etherscanConfig.apiKey === undefined ||
+    typeof etherscanConfig.apiKey !== "object"
+  ) {
+    return [];
+  }
+
+  const allowed = Object.keys(chainConfig);
+  const actual = Object.keys(etherscanConfig.apiKey);
+
+  return actual.filter((chain: string) => !allowed.includes(chain));
+};
 
 export const etherscanConfigExtender: ConfigExtender = (
   resolvedConfig,
@@ -8,6 +27,16 @@ export const etherscanConfigExtender: ConfigExtender = (
 
   if (config.etherscan !== undefined) {
     const customConfig = config.etherscan;
+
+    const unallowedChains = verifyAllowedChains(customConfig);
+
+    if (unallowedChains.length > 0) {
+      throw new NomicLabsHardhatPluginError(
+        pluginName,
+        `Etherscan API token "${unallowedChains[0]}" is for an unsupported network`
+      );
+    }
+
     resolvedConfig.etherscan = { ...defaultConfig, ...customConfig };
   } else {
     resolvedConfig.etherscan = defaultConfig;

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -50,7 +50,7 @@ import {
   getEtherscanEndpoints,
   retrieveContractBytecode,
 } from "./network/prober";
-import resolveEtherscanApiKey from "./resolveEtherscanApiKey";
+import { resolveEtherscanApiKey } from "./resolveEtherscanApiKey";
 import {
   Bytecode,
   ContractInformation,

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -45,11 +45,12 @@ import {
   toCheckStatusRequest,
   toVerifyRequest,
 } from "./etherscan/EtherscanVerifyContractRequest";
+import { chainConfig } from "./ChainConfig";
 import {
-  EtherscanURLs,
   getEtherscanEndpoints,
   retrieveContractBytecode,
 } from "./network/prober";
+import resolveEtherscanApiKey from "./resolveEtherscanApiKey";
 import {
   Bytecode,
   ContractInformation,
@@ -63,6 +64,7 @@ import {
 } from "./solc/metadata";
 import { getLongVersion } from "./solc/version";
 import "./type-extensions";
+import { EtherscanNetworkEntry, EtherscanURLs } from "./types";
 
 interface VerificationArgs {
   address: string;
@@ -156,15 +158,6 @@ const verifySubtask: ActionType<VerificationSubtaskArgs> = async (
 ) => {
   const { etherscan } = config;
 
-  if (etherscan.apiKey === undefined || etherscan.apiKey.trim() === "") {
-    throw new NomicLabsHardhatPluginError(
-      pluginName,
-      `Please provide an Etherscan API token via hardhat config.
-E.g.: { [...], etherscan: { apiKey: 'an API key' }, [...] }
-See https://etherscan.io/apis`
-    );
-  }
-
   const { isAddress } = await import("@ethersproject/address");
   if (!isAddress(address)) {
     throw new NomicLabsHardhatPluginError(
@@ -191,8 +184,14 @@ If your constructor has no arguments pass an empty array. E.g:
     TASK_VERIFY_GET_COMPILER_VERSIONS
   );
 
-  const etherscanAPIEndpoints: EtherscanURLs = await run(
-    TASK_VERIFY_GET_ETHERSCAN_ENDPOINT
+  const {
+    network: verificationNetwork,
+    urls: etherscanAPIEndpoints,
+  }: EtherscanNetworkEntry = await run(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT);
+
+  const etherscanAPIKey = resolveEtherscanApiKey(
+    etherscan,
+    verificationNetwork
   );
 
   const deployedBytecodeHex = await retrieveContractBytecode(
@@ -283,10 +282,11 @@ Possible causes are:
     contractInformation,
     etherscanAPIEndpoints,
     address,
-    etherscanAPIKey: etherscan.apiKey,
+    etherscanAPIKey,
     solcFullVersion,
     deployArgumentsEncoded,
   });
+
   if (success) {
     return;
   }
@@ -296,7 +296,7 @@ Possible causes are:
     etherscanAPIEndpoints,
     contractInformation,
     address,
-    etherscan.apiKey,
+    etherscanAPIKey,
     contractInformation.compilerInput,
     solcFullVersion,
     deployArgumentsEncoded
@@ -443,7 +443,7 @@ async function attemptVerification(
   console.log(
     `Successfully submitted source code for contract
 ${contractInformation.sourceName}:${contractInformation.contractName} at ${contractAddress}
-for verification on Etherscan. Waiting for verification result...
+for verification on the block explorer. Waiting for verification result...
 `
   );
 
@@ -592,7 +592,7 @@ See https://etherscan.io/solcversions for more information.`
 );
 
 subtask(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT).setAction(async (_, { network }) =>
-  getEtherscanEndpoints(network.provider, network.name)
+  getEtherscanEndpoints(network.provider, network.name, chainConfig)
 );
 
 subtask(TASK_VERIFY_GET_CONTRACT_INFORMATION)
@@ -729,6 +729,7 @@ subtask(TASK_VERIFY_VERIFY_MINIMUM_BUILD)
         minimumBuild.output.contracts[contractInformation.sourceName][
           contractInformation.contractName
         ].evm.deployedBytecode.object;
+
       const matchedBytecode =
         contractInformation.compilerOutput.contracts[
           contractInformation.sourceName

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -5,140 +5,13 @@ import {
 import { EthereumProvider } from "hardhat/types";
 
 import { pluginName } from "../constants";
-
-export interface EtherscanURLs {
-  apiURL: string;
-  browserURL: string;
-}
-
-type NetworkMap = {
-  [networkID in NetworkID]: EtherscanURLs;
-};
-
-// See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
-enum NetworkID {
-  MAINNET = 1,
-  ROPSTEN = 3,
-  RINKEBY = 4,
-  GOERLI = 5,
-  KOVAN = 42,
-  // Binance Smart Chain
-  BSC = 56,
-  BSC_TESTNET = 97,
-  // Huobi ECO Chain
-  HECO = 128,
-  HECO_TESTNET = 256,
-  // Fantom mainnet
-  OPERA = 250,
-  FTM_TESTNET = 4002,
-  // Optimistim
-  OPTIMISTIC_ETHEREUM = 10,
-  OPTIMISTIC_KOVAN = 69,
-  // Polygon
-  POLYGON = 137,
-  POLYGON_MUMBAI = 80001,
-  // Arbitrum
-  ARBITRUM_ONE = 42161,
-  ARBITRUM_TESTNET = 421611,
-  // Avalanche
-  AVALANCHE = 43114,
-  AVALANCHE_FUJI_TESTNET = 43113,
-  // Moonriver
-  MOONRIVER = 1285,
-  MOONBASE_ALPHA = 1287,
-}
-
-const networkIDtoEndpoints: NetworkMap = {
-  [NetworkID.MAINNET]: {
-    apiURL: "https://api.etherscan.io/api",
-    browserURL: "https://etherscan.io",
-  },
-  [NetworkID.ROPSTEN]: {
-    apiURL: "https://api-ropsten.etherscan.io/api",
-    browserURL: "https://ropsten.etherscan.io",
-  },
-  [NetworkID.RINKEBY]: {
-    apiURL: "https://api-rinkeby.etherscan.io/api",
-    browserURL: "https://rinkeby.etherscan.io",
-  },
-  [NetworkID.GOERLI]: {
-    apiURL: "https://api-goerli.etherscan.io/api",
-    browserURL: "https://goerli.etherscan.io",
-  },
-  [NetworkID.KOVAN]: {
-    apiURL: "https://api-kovan.etherscan.io/api",
-    browserURL: "https://kovan.etherscan.io",
-  },
-  [NetworkID.BSC]: {
-    apiURL: "https://api.bscscan.com/api",
-    browserURL: "https://bscscan.com",
-  },
-  [NetworkID.BSC_TESTNET]: {
-    apiURL: "https://api-testnet.bscscan.com/api",
-    browserURL: "https://testnet.bscscan.com",
-  },
-  [NetworkID.HECO]: {
-    apiURL: "https://api.hecoinfo.com/api",
-    browserURL: "https://hecoinfo.com",
-  },
-  [NetworkID.HECO_TESTNET]: {
-    apiURL: "https://api-testnet.hecoinfo.com/api",
-    browserURL: "https://testnet.hecoinfo.com",
-  },
-  [NetworkID.OPERA]: {
-    apiURL: "https://api.ftmscan.com/api",
-    browserURL: "https://ftmscan.com",
-  },
-  [NetworkID.FTM_TESTNET]: {
-    apiURL: "https://api-testnet.ftmscan.com/api",
-    browserURL: "https://testnet.ftmscan.com",
-  },
-  [NetworkID.OPTIMISTIC_ETHEREUM]: {
-    apiURL: "https://api-optimistic.etherscan.io/api",
-    browserURL: "https://optimistic.etherscan.io/",
-  },
-  [NetworkID.OPTIMISTIC_KOVAN]: {
-    apiURL: "https://api-kovan-optimistic.etherscan.io/api",
-    browserURL: "https://kovan-optimistic.etherscan.io/",
-  },
-  [NetworkID.POLYGON]: {
-    apiURL: "https://api.polygonscan.com/api",
-    browserURL: "https://polygonscan.com",
-  },
-  [NetworkID.POLYGON_MUMBAI]: {
-    apiURL: "https://api-testnet.polygonscan.com/api",
-    browserURL: "https://mumbai.polygonscan.com/",
-  },
-  [NetworkID.ARBITRUM_ONE]: {
-    apiURL: "https://api.arbiscan.io/api",
-    browserURL: "https://arbiscan.io/",
-  },
-  [NetworkID.ARBITRUM_TESTNET]: {
-    apiURL: "https://api-testnet.arbiscan.io/api",
-    browserURL: "https://testnet.arbiscan.io/",
-  },
-  [NetworkID.AVALANCHE]: {
-    apiURL: "https://api.snowtrace.io/api",
-    browserURL: "https://snowtrace.io/",
-  },
-  [NetworkID.AVALANCHE_FUJI_TESTNET]: {
-    apiURL: "https://api-testnet.snowtrace.io/api",
-    browserURL: "https://testnet.snowtrace.io/",
-  },
-  [NetworkID.MOONRIVER]: {
-    apiURL: "https://api-moonriver.moonscan.io/api",
-    browserURL: "https://moonscan.io",
-  },
-  [NetworkID.MOONBASE_ALPHA]: {
-    apiURL: "https://api-moonbase.moonscan.io/api",
-    browserURL: "https://moonbase.moonscan.io/",
-  },
-};
+import { EtherscanNetworkEntry, ChainConfig } from "../types";
 
 export async function getEtherscanEndpoints(
   provider: EthereumProvider,
-  networkName: string
-): Promise<EtherscanURLs> {
+  networkName: string,
+  chainConfig: ChainConfig
+): Promise<EtherscanNetworkEntry> {
   if (networkName === HARDHAT_NETWORK_NAME) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
@@ -146,9 +19,18 @@ export async function getEtherscanEndpoints(
     );
   }
 
-  const chainID = parseInt(await provider.send("eth_chainId"), 16) as NetworkID;
+  const chainIdsToNames = new Map(
+    Object.entries(chainConfig).map(([mapName, config]) => [
+      config.chainId,
+      mapName,
+    ])
+  );
 
-  const endpoints = networkIDtoEndpoints[chainID];
+  const chainID = parseInt(await provider.send("eth_chainId"), 16);
+
+  const network = chainIdsToNames.get(chainID) as keyof ChainConfig;
+
+  const endpoints = network !== undefined ? chainConfig[network] : undefined;
 
   if (endpoints === undefined) {
     throw new NomicLabsHardhatPluginError(
@@ -161,7 +43,7 @@ Possible causes are:
     );
   }
 
-  return endpoints;
+  return { network, urls: endpoints.urls };
 }
 
 export async function retrieveContractBytecode(

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -33,12 +33,7 @@ export async function getEtherscanEndpoints(
   if (network === undefined) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
-      `An etherscan endpoint could not be found for this network. ChainID: ${chainID}. The selected network is ${networkName}.
-
-Possible causes are:
-  - The network is not supported by hardhat-etherscan.
-  - The selected network (${networkName}) is wrong.
-  - Faulty hardhat network config.`
+      `Unsupported network ("${networkName}", chainId: ${chainID}).`
     );
   }
 

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -12,13 +12,7 @@ export const resolveEtherscanApiKey = (
   network: string
 ): string => {
   if (etherscan.apiKey === undefined || etherscan.apiKey === "") {
-    throw new NomicLabsHardhatPluginError(
-      pluginName,
-      `Please provide an Etherscan API token via hardhat config.
-  E.g.: { [...], etherscan: { apiKey: 'an API key' }, [...] }
-  or { [...], etherscan: { apiKey: { mainnet: 'an API key' } }, [...] }
-  See https://etherscan.io/apis`
-    );
+    throwMissingApiKeyError(network);
   }
 
   if (typeof etherscan.apiKey === "string") {
@@ -37,12 +31,26 @@ export const resolveEtherscanApiKey = (
   const key = apiKeys[network];
 
   if (key === undefined || key === "") {
-    throw new NomicLabsHardhatPluginError(
-      pluginName,
-      `Please provide a Block Explorer API token via hardhat config.
-  E.g.: { [...], etherscan: { apiKey: { ${network}: 'an API key' } }, [...] }`
-    );
+    throwMissingApiKeyError(network);
   }
 
   return key;
 };
+
+function throwMissingApiKeyError(network: string): never {
+  throw new NomicLabsHardhatPluginError(
+    pluginName,
+    `Please provide an Etherscan API token via hardhat config. For example:
+
+{
+  ...
+  etherscan: {
+    apiKey: {
+      ${network}: 'your API key'
+    }
+  }
+}
+
+See https://etherscan.io/apis`
+  );
+}

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -1,4 +1,4 @@
-import { NomicLabsHardhatPluginError } from "hardhat/src/plugins";
+import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { pluginName } from "./constants";
 import { chainConfig } from "./ChainConfig";
 import { EtherscanConfig, ChainConfig } from "./types";

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -1,0 +1,50 @@
+import { NomicLabsHardhatPluginError } from "hardhat/src/plugins";
+import { pluginName } from "./constants";
+import { chainConfig } from "./ChainConfig";
+import { EtherscanConfig, ChainConfig } from "./types";
+
+const isNetworkKey = (network: string): network is keyof ChainConfig => {
+  return network in chainConfig;
+};
+
+const resolveEtherscanApiKey = (
+  etherscan: EtherscanConfig,
+  network: string
+): string => {
+  if (etherscan.apiKey === undefined || etherscan.apiKey === "") {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `Please provide an Etherscan API token via hardhat config.
+  E.g.: { [...], etherscan: { apiKey: 'an API key' }, [...] }
+  or { [...], etherscan: { apiKey: { mainnet: 'an API key' } }, [...] }
+  See https://etherscan.io/apis`
+    );
+  }
+
+  if (typeof etherscan.apiKey === "string") {
+    return etherscan.apiKey;
+  }
+
+  const apiKeys = etherscan.apiKey;
+
+  if (!isNetworkKey(network)) {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `Unrecognized network: ${network}`
+    );
+  }
+
+  const key = apiKeys[network];
+
+  if (key === undefined || key === "") {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `Please provide a Block Explorer API token via hardhat config.
+  E.g.: { [...], etherscan: { apiKey: { ${network}: 'an API key' } }, [...] }`
+    );
+  }
+
+  return key;
+};
+
+export default resolveEtherscanApiKey;

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -7,7 +7,7 @@ const isNetworkKey = (network: string): network is keyof ChainConfig => {
   return network in chainConfig;
 };
 
-const resolveEtherscanApiKey = (
+export const resolveEtherscanApiKey = (
   etherscan: EtherscanConfig,
   network: string
 ): string => {
@@ -46,5 +46,3 @@ const resolveEtherscanApiKey = (
 
   return key;
 };
-
-export default resolveEtherscanApiKey;

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -1,43 +1,40 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
-export enum Chains {
-  mainnet = "mainnet",
-  ropsten = "ropsten",
-  rinkeby = "rinkeby",
-  goerli = "goerli",
-  kovan = "kovan",
+type Chain =
+  | "mainnet"
+  | "ropsten"
+  | "rinkeby"
+  | "goerli"
+  | "kovan"
   // binance smart chain
-  bsc = "bsc",
-  bscTestnet = "bscTestnet",
+  | "bsc"
+  | "bscTestnet"
   // huobi eco chain
-  heco = "heco",
-  hecoTestnet = "hecoTestnet",
+  | "heco"
+  | "hecoTestnet"
   // fantom mainnet
-  opera = "opera",
-  ftmTestnet = "ftmTestnet",
+  | "opera"
+  | "ftmTestnet"
   // optimistim
-  optimisticEthereum = "optimisticEthereum",
-  optimisticKovan = "optimisticKovan",
+  | "optimisticEthereum"
+  | "optimisticKovan"
   // polygon
-  polygon = "polygon",
-  polygonMumbai = "polygonMumbai",
+  | "polygon"
+  | "polygonMumbai"
   // arbitrum
-  arbitrumOne = "arbitrumOne",
-  arbitrumTestnet = "arbitrumTestnet",
+  | "arbitrumOne"
+  | "arbitrumTestnet"
   // avalanche
-  avalanche = "avalanche",
-  avalancheFujiTestnet = "avalancheFujiTestnet",
+  | "avalanche"
+  | "avalancheFujiTestnet"
   // moonriver
-  moonriver = "moonriver",
-  moonbaseAlpha = "moonbaseAlpha",
-}
+  | "moonriver"
+  | "moonbaseAlpha";
 
 export type ChainConfig = {
-  [Network in Chains]: EtherscanChainConfig;
+  [Network in Chain]: EtherscanChainConfig;
 };
 
-export type EtherscanApiKeys = {
-  [Network in keyof ChainConfig]?: string;
+type EtherscanApiKeys = {
+  [Network in Chain]?: string;
 };
 
 export interface EtherscanConfig {
@@ -49,12 +46,12 @@ export interface EtherscanURLs {
   browserURL: string;
 }
 
-export interface EtherscanChainConfig {
+interface EtherscanChainConfig {
   chainId: number;
   urls: EtherscanURLs;
 }
 
 export interface EtherscanNetworkEntry {
-  network: Chains;
+  network: Chain;
   urls: EtherscanURLs;
 }

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -1,3 +1,60 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export enum Chains {
+  mainnet = "mainnet",
+  ropsten = "ropsten",
+  rinkeby = "rinkeby",
+  goerli = "goerli",
+  kovan = "kovan",
+  // binance smart chain
+  bsc = "bsc",
+  bsc_testnet = "bsc_testnet",
+  // huobi eco chain
+  heco = "heco",
+  heco_testnet = "heco_testnet",
+  // fantom mainnet
+  opera = "opera",
+  ftm_testnet = "ftm_testnet",
+  // optimistim
+  optimistic_ethereum = "optimistic_ethereum",
+  optimistic_kovan = "optimistic_kovan",
+  // polygon
+  polygon = "polygon",
+  polygon_mumbai = "polygon_mumbai",
+  // arbitrum
+  arbitrum_one = "arbitrum_one",
+  arbitrum_testnet = "arbitrum_testnet",
+  // avalanche
+  avalanche = "avalanche",
+  avalanche_fuji_testnet = "avalanche_fuji_testnet",
+  // moonriver
+  moonriver = "moonriver",
+  moonbase_alpha = "moonbase_alpha",
+}
+
+export type ChainConfig = {
+  [Network in Chains]: EtherscanChainConfig;
+};
+
+export type EtherscanApiKeys = {
+  [Network in keyof ChainConfig]?: string;
+};
+
 export interface EtherscanConfig {
-  apiKey?: string;
+  apiKey?: string | EtherscanApiKeys;
+}
+
+export interface EtherscanURLs {
+  apiURL: string;
+  browserURL: string;
+}
+
+export interface EtherscanChainConfig {
+  chainId: number;
+  urls: EtherscanURLs;
+}
+
+export interface EtherscanNetworkEntry {
+  network: Chains;
+  urls: EtherscanURLs;
 }

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -8,28 +8,28 @@ export enum Chains {
   kovan = "kovan",
   // binance smart chain
   bsc = "bsc",
-  bsc_testnet = "bsc_testnet",
+  bscTestnet = "bscTestnet",
   // huobi eco chain
   heco = "heco",
-  heco_testnet = "heco_testnet",
+  hecoTestnet = "hecoTestnet",
   // fantom mainnet
   opera = "opera",
-  ftm_testnet = "ftm_testnet",
+  ftmTestnet = "ftmTestnet",
   // optimistim
-  optimistic_ethereum = "optimistic_ethereum",
-  optimistic_kovan = "optimistic_kovan",
+  optimisticEthereum = "optimisticEthereum",
+  optimisticKovan = "optimisticKovan",
   // polygon
   polygon = "polygon",
-  polygon_mumbai = "polygon_mumbai",
+  polygonMumbai = "polygonMumbai",
   // arbitrum
-  arbitrum_one = "arbitrum_one",
-  arbitrum_testnet = "arbitrum_testnet",
+  arbitrumOne = "arbitrumOne",
+  arbitrumTestnet = "arbitrumTestnet",
   // avalanche
   avalanche = "avalanche",
-  avalanche_fuji_testnet = "avalanche_fuji_testnet",
+  avalancheFujiTestnet = "avalancheFujiTestnet",
   // moonriver
   moonriver = "moonriver",
-  moonbase_alpha = "moonbase_alpha",
+  moonbaseAlpha = "moonbaseAlpha",
 }
 
 export type ChainConfig = {

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/.gitignore
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/artifacts-dir

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/contracts/TestContract.sol
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/contracts/TestContract.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.5.15;
+
+contract TestContract {
+
+    uint amount;
+
+    string message = "placeholder";
+
+    constructor(uint _amount) public {
+        amount = _amount + 20;
+    }
+}

--- a/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/hardhat.config.js
+++ b/packages/hardhat-etherscan/test/fixture-projects/hardhat-project-multiple-apikeys-config/hardhat.config.js
@@ -1,0 +1,13 @@
+require("../../../src/index");
+
+module.exports = {
+  etherscan: {
+    apiKey: {
+      mainnet: "mainnet-testtoken",
+      ropsten: "ropsten-testtoken",
+    },
+  },
+  solidity: {
+    version: "0.5.15",
+  },
+};

--- a/packages/hardhat-etherscan/test/integration/HardhatRuntimeEnvironmentExtensionTests.ts
+++ b/packages/hardhat-etherscan/test/integration/HardhatRuntimeEnvironmentExtensionTests.ts
@@ -22,4 +22,23 @@ describe("hardhat-etherscan configuration defaults in an empty project", functio
   it("the etherscan field should be present", function () {
     assert.isDefined(this.env.config.etherscan);
   });
+
+  it("the apiKey subfield should be the empty string", function () {
+    assert.equal(this.env.config.etherscan.apiKey, "");
+  });
+});
+
+describe("hardhat-etherscan configuration with multiple api keys", function () {
+  useEnvironment("hardhat-project-multiple-apikeys-config", "hardhat");
+
+  it("the etherscan field should be present", function () {
+    assert.isDefined(this.env.config.etherscan);
+  });
+
+  it("the apiKey subfield should be the apiKeys object", function () {
+    assert.deepEqual(this.env.config.etherscan.apiKey, {
+      mainnet: "mainnet-testtoken",
+      ropsten: "ropsten-testtoken",
+    });
+  });
 });

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -3,7 +3,9 @@ import { chainConfig } from "../../src/ChainConfig";
 
 describe("Chain Config", () => {
   it("should have no duplicate chain ids", () => {
-    const chainIds = Object.values(chainConfig).map((config) => config.chainId);
+    const chainIds: number[] = Object.values(chainConfig).map(
+      (config) => config.chainId
+    );
 
     const uniqueIds = [...new Set(chainIds)];
 

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -3,7 +3,7 @@ import { chainConfig } from "../../src/ChainConfig";
 
 describe("Chain Config", () => {
   it("should have no duplicate chain ids", () => {
-    const chainIds = Object.values(chainConfig);
+    const chainIds = Object.values(chainConfig).map((config) => config.chainId);
 
     const uniqueIds = [...new Set(chainIds)];
 

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -1,0 +1,13 @@
+import { assert } from "chai";
+import { chainConfig } from "../../src/ChainConfig";
+
+describe("Chain Config", () => {
+  it("should have no duplicate chain ids", () => {
+    const chainIds = Object.values(chainConfig);
+
+    const uniqueIds = [...new Set(chainIds)];
+
+    assert.notEqual(0, uniqueIds.length);
+    assert.equal(uniqueIds.length, chainIds.length);
+  });
+});

--- a/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
+++ b/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
@@ -32,7 +32,7 @@ describe("Config extension", () => {
     });
   });
 
-  it("should error on providing unsupported api keys", () => {
+  it("should error on providing unsupported api key", () => {
     assert.throws(() => {
       const resolvedConfig = {} as HardhatConfig;
 
@@ -40,6 +40,23 @@ describe("Config extension", () => {
         etherscan: {
           apiKey: {
             newhotness: "example_token",
+          },
+        },
+      } as any;
+
+      etherscanConfigExtender(resolvedConfig, invalidEtherscanConfig);
+    }, 'Etherscan API token "newhotness" is for an unsupported network');
+  });
+
+  it("should error on providing multiple unsupported api keys", () => {
+    assert.throws(() => {
+      const resolvedConfig = {} as HardhatConfig;
+
+      const invalidEtherscanConfig = {
+        etherscan: {
+          apiKey: {
+            newhotness: "example_token",
+            newhotness2: "example_token",
           },
         },
       } as any;

--- a/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
+++ b/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
@@ -1,0 +1,50 @@
+import { assert } from "chai";
+import { HardhatConfig } from "hardhat/types/config";
+import { etherscanConfigExtender } from "../../src/config";
+
+describe("Config extension", () => {
+  it("should enforce a default config if none provided", () => {
+    const resolvedConfig = {} as HardhatConfig;
+    etherscanConfigExtender(resolvedConfig, {});
+
+    assert.deepStrictEqual(resolvedConfig.etherscan, { apiKey: "" });
+  });
+
+  it("copy across a string api key", () => {
+    const resolvedConfig = {} as HardhatConfig;
+    etherscanConfigExtender(resolvedConfig, {
+      etherscan: { apiKey: "example_token" },
+    });
+
+    assert.deepStrictEqual(resolvedConfig.etherscan, {
+      apiKey: "example_token",
+    });
+  });
+
+  it("copy across an etherscan api keys object", () => {
+    const resolvedConfig = {} as HardhatConfig;
+    etherscanConfigExtender(resolvedConfig, {
+      etherscan: { apiKey: { ropsten: "example_token" } },
+    });
+
+    assert.deepStrictEqual(resolvedConfig.etherscan, {
+      apiKey: { ropsten: "example_token" },
+    });
+  });
+
+  it("should error on providing unsupported api keys", () => {
+    assert.throws(() => {
+      const resolvedConfig = {} as HardhatConfig;
+
+      const invalidEtherscanConfig = {
+        etherscan: {
+          apiKey: {
+            newhotness: "example_token",
+          },
+        },
+      } as any;
+
+      etherscanConfigExtender(resolvedConfig, invalidEtherscanConfig);
+    }, 'Etherscan API token "newhotness" is for an unsupported network');
+  });
+});

--- a/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
@@ -1,0 +1,91 @@
+import { assert } from "chai";
+import resolveEtherscanApiKey from "../../src/resolveEtherscanApiKey";
+import { EtherscanConfig } from "../../src/types";
+
+describe("Etherscan API Key resolution", () => {
+  describe("provide one api key", () => {
+    it("returns the api key no matter the network", () => {
+      assert.equal(
+        resolveEtherscanApiKey({ apiKey: "testtoken" }, "mainnet"),
+        "testtoken"
+      );
+
+      assert.equal(
+        resolveEtherscanApiKey({ apiKey: "testtoken" }, "rinkeby"),
+        "testtoken"
+      );
+    });
+  });
+
+  describe("provide multiple api keys", () => {
+    it("can retrieve different keys depending on --network", () => {
+      const etherscanConfig: EtherscanConfig = {
+        apiKey: {
+          mainnet: "mainnet-testtoken",
+          rinkeby: "rinkeby-testtoken",
+        },
+      };
+
+      assert.equal(
+        resolveEtherscanApiKey(etherscanConfig, "mainnet"),
+        "mainnet-testtoken"
+      );
+      assert.equal(
+        resolveEtherscanApiKey(etherscanConfig, "rinkeby"),
+        "rinkeby-testtoken"
+      );
+    });
+
+    it("should throw if api key is for unrecognized network", () => {
+      assert.throws(() =>
+        resolveEtherscanApiKey(
+          // @ts-expect-error
+          { apiKey: { newthing: "testtoken" } },
+          "newthing"
+        )
+      );
+    });
+  });
+
+  describe("provide no api key", () => {
+    const expectedBadApiKeyMessage =
+      "Please provide an Etherscan API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: 'an API key' }, [...] }\n  or { [...], etherscan: { apiKey: { mainnet: 'an API key' } }, [...] }\n  See https://etherscan.io/apis";
+
+    it("should throw if api key root is undefined", () => {
+      assert.throws(
+        () => resolveEtherscanApiKey({ apiKey: undefined }, "rinkeby"),
+        expectedBadApiKeyMessage
+      );
+    });
+
+    it("should throw if api key root is empty string", () => {
+      assert.throws(
+        () => resolveEtherscanApiKey({ apiKey: "" }, "rinkeby"),
+        expectedBadApiKeyMessage
+      );
+    });
+
+    it("should throw if network subkey is undefined", () => {
+      assert.throws(
+        () =>
+          resolveEtherscanApiKey({ apiKey: { rinkeby: undefined } }, "rinkeby"),
+        "Please provide a Block Explorer API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: { rinkeby: 'an API key' } }, [...] }"
+      );
+    });
+
+    it("should throw if network subkey is empty string", () => {
+      assert.throws(
+        () => resolveEtherscanApiKey({ apiKey: { rinkeby: "" } }, "rinkeby"),
+        "Please provide a Block Explorer API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: { rinkeby: 'an API key' } }, [...] }"
+      );
+    });
+
+    it("should throw if network subkey is not a supported network", () => {
+      assert.throws(
+        // @ts-expect-error
+        () => resolveEtherscanApiKey({ apiKey: { boom: "" } }, "boom"),
+        "Unrecognized network: boom"
+      );
+    });
+  });
+});

--- a/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import resolveEtherscanApiKey from "../../src/resolveEtherscanApiKey";
+import { resolveEtherscanApiKey } from "../../src/resolveEtherscanApiKey";
 import { EtherscanConfig } from "../../src/types";
 
 describe("Etherscan API Key resolution", () => {

--- a/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
@@ -49,7 +49,7 @@ describe("Etherscan API Key resolution", () => {
 
   describe("provide no api key", () => {
     const expectedBadApiKeyMessage =
-      "Please provide an Etherscan API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: 'an API key' }, [...] }\n  or { [...], etherscan: { apiKey: { mainnet: 'an API key' } }, [...] }\n  See https://etherscan.io/apis";
+      /Please provide an Etherscan API token via hardhat config/;
 
     it("should throw if api key root is undefined", () => {
       assert.throws(
@@ -69,14 +69,14 @@ describe("Etherscan API Key resolution", () => {
       assert.throws(
         () =>
           resolveEtherscanApiKey({ apiKey: { rinkeby: undefined } }, "rinkeby"),
-        "Please provide a Block Explorer API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: { rinkeby: 'an API key' } }, [...] }"
+        /Please provide an Etherscan API token via hardhat config./
       );
     });
 
     it("should throw if network subkey is empty string", () => {
       assert.throws(
         () => resolveEtherscanApiKey({ apiKey: { rinkeby: "" } }, "rinkeby"),
-        "Please provide a Block Explorer API token via hardhat config.\n  E.g.: { [...], etherscan: { apiKey: { rinkeby: 'an API key' } }, [...] }"
+        /Please provide an Etherscan API token via hardhat config./
       );
     });
 


### PR DESCRIPTION
Etherscan has expanded to provided block explorers and verifiers for popular sidechains. The config in the `hardhat-etherscan` plugin assumes there is only one `apiKey` for use in verification, even though the project may be targeting multiple network/sidechains.

This PR adds support in the `hardhat-etherscan` configuration for setting an api key for etherscan per network (i.e. a project could support project verification on both mainnet and polygon at once without hacks).

## Approach

Extend the current allowed structure of the `hardhat-etherscan` from:

```javascript
{
   etherscan: {
      apiKey: string, 
   }
}
```

to:

```javascript
{
   etherscan: {
      apiKey: string | EtherscanApiKeys, 
   }
}
```

Where `EtherscanApiKeys` is an object with one property for each supported network mapping to the apiKey to used when verifying on that network.

The supported networks are derived from the `networkConfig` object that combines the chainId and etherscan urls, and is used to define the typesafety of the etherscan config object (only networks present on the config object are allowed in a valid etherscan config).

Relates to #1448

## TODO

We'll release a new major version.
* [x] Add support for `EtherscanApiKeys` under etherscan config
* [x] Refactor supported networks so that each one has a name (used in the EtherscanApiKeys type)
* [x] The relationship between supported networks and EtherscanApiKeys should be typesafe
* [x] The key to be used when verifying a contract should be the one that maps to the currently selected network if the using EtherscanApiKeys, or the apiKey string otherwise
* [x] Update the README
* [x] Update the contribution guide
* [x] Manual testing against a sample of alternate networks
