### PR TITLE
Update pragma version from ^0.7.3 to >=0.7.3

### DIFF
--- a/docs/tutorial/writing-and-compiling-contracts.md
+++ b/docs/tutorial/writing-and-compiling-contracts.md
@@ -29,7 +29,7 @@ To get syntax highlighting you should add Solidity support to your text editor. 
 ```solidity
 // Solidity files have to start with this pragma.
 // It will be used by the Solidity compiler to validate its version.
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0;
 
 
 // This is the main building block for smart contracts.


### PR DESCRIPTION
Update pragma version from ^0.7.3 to >=0.7.3 to prevent error of 'Source file requires different compiler version' in VSCode using solidity extension.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
