### PR TITLE
Add @primitivefi/hardhat-dodoc to the plugins

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -298,7 +298,8 @@ module.exports.communityPlugins = [
     name: "@primitivefi/hardhat-dodoc",
     author: "Primitive",
     authorUrl: "https://github.com/primitivefinance/primitive-dodoc",
-    description: "Zero-config Hardhat plugin to generate documentation for all your Solidity contracts.",
+    description:
+      "Zero-config Hardhat plugin to generate documentation for all your Solidity contracts.",
     tags: ["Documentation", "Docs", "Solidity", "NatSpec"],
   },
 ];

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -294,6 +294,13 @@ module.exports.communityPlugins = [
       "Hardhat plugin to compile the Yul and Yul+ languages into solc compatible artifacts. Works with .yul and .yulp file extensions",
     tags: ["Yul", "Assembly", "Compiler", "Yul+"],
   },
+  {
+    name: "@primitivefi/hardhat-dodoc",
+    author: "Primitive",
+    authorUrl: "https://github.com/primitivefinance/primitive-dodoc",
+    description: "Zero-config Hardhat plugin to generate documentation for all your Solidity contracts.",
+    tags: ["Documentation", "Docs", "Solidity", "NatSpec"],
+  },
 ];
 
 module.exports.officialPlugins = [


### PR DESCRIPTION
I just released a new plugin to generate documentation based on the NatSpec comments of the contracts.
Can we add it to the community plugins list?
