### PR TITLE
Add eslint rule to ensure no default exports

### DIFF
--- a/config/eslint/eslintrc.js
+++ b/config/eslint/eslintrc.js
@@ -170,6 +170,7 @@ module.exports = {
         ],
       },
     ],
+    "import/no-default-export": "error",
     "no-bitwise": "error",
     "no-caller": "error",
     "no-cond-assign": "error",

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/handler.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/handler.ts
@@ -20,7 +20,7 @@ import {
 
 /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
 
-export default class JsonRpcHandler {
+export class JsonRpcHandler {
   constructor(private readonly _provider: EIP1193Provider) {}
 
   public handleHttp = async (req: IncomingMessage, res: ServerResponse) => {

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../types";
 import { HttpProvider } from "../../core/providers/http";
 
-import JsonRpcHandler from "./handler";
+import { JsonRpcHandler } from "./handler";
 
 const log = debug("hardhat:core:hardhat-network:jsonrpc");
 

--- a/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/hardhat-etherscan/src/etherscan/EtherscanService.ts
@@ -129,7 +129,7 @@ Reason: ${etherscanResponse.message}`
   return etherscanResponse;
 }
 
-export default class EtherscanResponse {
+export class EtherscanResponse {
   public readonly status: number;
 
   public readonly message: string;

--- a/packages/hardhat-ganache/src/ganache-options-ti.ts
+++ b/packages/hardhat-ganache/src/ganache-options-ti.ts
@@ -50,4 +50,5 @@ export const GanacheOptionsTi = t.iface([], {
 const exportedTypeSuite: t.ITypeSuite = {
   GanacheOptionsTi,
 };
+// eslint-disable-next-line import/no-default-export
 export default exportedTypeSuite;

--- a/packages/hardhat-truffle4/test/fixture-projects/hardhat-project-with-ts-fixture/test/truffle-fixture.ts
+++ b/packages/hardhat-truffle4/test/fixture-projects/hardhat-project-with-ts-fixture/test/truffle-fixture.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-default-export
 export default function fixture() {}

--- a/packages/hardhat-truffle5/test/fixture-projects/hardhat-project-with-ts-fixture/test/truffle-fixture.ts
+++ b/packages/hardhat-truffle5/test/fixture-projects/hardhat-project-with-ts-fixture/test/truffle-fixture.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-default-export
 export default function fixture() {}


### PR DESCRIPTION
As part of hardhats coding conventions we prefer named over default exports from modules. This PR enables an eslint rule to support this.

This is using the eslint import plugin (already installed) and updates the global config.

## Preview

![image](https://user-images.githubusercontent.com/24030/146384033-90162d5c-2c0f-4f37-a960-4358521e1a26.png)
