### PR TITLE
hardhat-core: Fix typo in README

### DIFF
--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -42,6 +42,6 @@ Go to [CONTRIBUTING.md](./CONTRIBUTING.md) to learn about how to set up Hardhat'
 
 [Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
 
-## Happy buidling!
+## Happy building!
 
 👷‍♀️👷‍♂️👷‍♀️👷‍♂️👷‍♀️👷‍♂️👷‍♀️👷‍♂️👷‍♀️👷‍♂️👷‍♀️👷‍♂️👷‍♀️👷‍♂️


### PR DESCRIPTION
This is a small change to fix a typo at the bottom of the `hardhat-core` README:
`buidling` --> `building`

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
