### PR TITLE
add unit for gasPrice

### DIFF
--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -30,7 +30,7 @@ Its value should be `"auto"` or a number. If a number is used, it will be the ga
 
 #### `gasPrice`
 
-Its value should be `"auto"` or a number. This parameter behaves like `gas`. Default value: `"auto"`.
+Its value should be `"auto"` or a number. This parameter behaves like `gas`. Default value: `"auto"`. The unit for this field is in Gwei.
 
 #### `gasMultiplier`
 

--- a/docs/hardhat-network/reference/README.md
+++ b/docs/hardhat-network/reference/README.md
@@ -30,7 +30,7 @@ Its value should be `"auto"` or a number. If a number is used, it will be the ga
 
 #### `gasPrice`
 
-Its value should be `"auto"` or a number. This parameter behaves like `gas`. Default value: `"auto"`. The unit for this field is in Gwei.
+Its value should be `"auto"` or a number (in wei). This parameter behaves like `gas`. Default value: `"auto"`.
 
 #### `gasMultiplier`
 


### PR DESCRIPTION
Make it more clear what the unit for gasPrice should be


- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Hello! I am fairly new to the web3 world but it took me a long time to figure out what the unit for gasPrice should be when trying to deploy to mainnet. I hope this helps other developers looking at the page.
