### PR TITLE
fixing optimism typo in `hardhat-etherscan` readme

### DIFF
--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -150,7 +150,7 @@ module.exports = {
         // fantom mainnet
         opera: "YOUR_FTMSCAN_API_KEY",
         ftmTestnet: "YOUR_FTMSCAN_API_KEY",
-        // optimistim
+        // optimism
         optimisticEthereum: "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
         optimisticKovan: "YOUR_OPTIMISTIC_ETHERSCAN_API_KEY",
         // polygon


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

In the new description regarding "multiple API keys and alternative block explorers" (btw I love that new feature) was a small typo in the word "optimistim". Not my greatest contribution ofc but I thought I would quickly fix this typo ;-). 
