### PR TITLE
adds moonbeam to hardhat etherscan verify

### DIFF
--- a/.changeset/poor-cycles-own.md
+++ b/.changeset/poor-cycles-own.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": minor
+---
+
+Adds moonbeam as a supported network

--- a/.changeset/poor-cycles-own.md
+++ b/.changeset/poor-cycles-own.md
@@ -2,4 +2,4 @@
 "@nomiclabs/hardhat-etherscan": patch
 ---
 
-Adds moonbeam as a supported network
+Add support for the Moonbeam network

--- a/.changeset/poor-cycles-own.md
+++ b/.changeset/poor-cycles-own.md
@@ -1,5 +1,5 @@
 ---
-"@nomiclabs/hardhat-etherscan": minor
+"@nomiclabs/hardhat-etherscan": patch
 ---
 
 Adds moonbeam as a supported network

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -162,9 +162,10 @@ module.exports = {
         // avalanche
         avalanche: "YOUR_SNOWTRACE_API_KEY",
         avalancheFujiTestnet: "YOUR_SNOWTRACE_API_KEY",
-        // moonriver
+        // moonbeam
+        moonbeam: "YOUR_MOONBEAM_MOONSCAN_API_KEY"
         moonriver: "YOUR_MOONRIVER_MOONSCAN_API_KEY",
-        moonbaseAlpha: "YOUR_MOONRIVER_MOONSCAN_API_KEY",
+        moonbaseAlpha: "YOUR_MOONBEAM_MOONSCAN_API_KEY",
         // xdai and sokol don't need an API key, but you still need
         // to specify one; any string placeholder will work
         xdai: "api-key",

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -135,11 +135,18 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://testnet.snowtrace.io/",
     },
   },
+  moonbeam: {
+    chainId: 1284,
+    urls: {
+      apiURL: "https://api-moonbeam.moonscan.io/api",
+      browserURL: "https://moonbeam.moonscan.io",
+    },
+  },
   moonriver: {
     chainId: 1285,
     urls: {
       apiURL: "https://api-moonriver.moonscan.io/api",
-      browserURL: "https://moonscan.io",
+      browserURL: "https://moonriver.moonscan.io",
     },
   },
   moonbaseAlpha: {

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -25,7 +25,8 @@ type Chain =
   // avalanche
   | "avalanche"
   | "avalancheFujiTestnet"
-  // moonriver
+  // moonbeam
+  | "moonbeam"
   | "moonriver"
   | "moonbaseAlpha"
   // xdai


### PR DESCRIPTION
- [x]  I didn't do anything of this.

---

This PR adds Moonbeam Network as a supported network for the `hardhat-etherscan` plugin. This was previously discussed in a PR that git merged already for Moonriver #2046 

https://moonbeam.network/
https://moonbeam.moonscan.io/
