### PR TITLE
Fixed typo in TS_NODE_NOT_INSTALLED error message

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -183,7 +183,7 @@ Please install Hardhat locally using npm or Yarn, and try again.`,
       number: 13,
       message: `Your Hardhat project uses typescript, but ts-node is not installed.
       
-Please run: npm \`install --save-dev ts-node\``,
+Please run: npm install --save-dev ts-node`,
       title: "ts-node not installed",
       description: `You are running a Hardhat project that uses typescript, but you haven't installed ts-node.
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Found a small typo for the `TS_NODE_NOT_INSTALLED` error, where the error message contains extra backticks in the npm command to install ts-node.
