### PR TITLE
Increase test timeout in truffle plugins

### DIFF
--- a/packages/hardhat-truffle4/.mocharc.json
+++ b/packages/hardhat-truffle4/.mocharc.json
@@ -2,5 +2,5 @@
   "require": "ts-node/register/files",
   "file": "../common/run-with-ganache",
   "ignore": ["test/fixture-projects/**/*"],
-  "timeout": 10000
+  "timeout": 20000
 }

--- a/packages/hardhat-truffle5/.mocharc.json
+++ b/packages/hardhat-truffle5/.mocharc.json
@@ -2,5 +2,5 @@
   "require": "ts-node/register/files",
   "file": "../common/run-with-ganache",
   "ignore": ["test/fixture-projects/**/*"],
-  "timeout": 10000
+  "timeout": 20000
 }


### PR DESCRIPTION
Checking if this makes the `hardhat-truffle` tests fail less often in the CI when macos is used.