### PR TITLE
Use NomicLabsHardhatPluginError in getWallets for error handling

### DIFF
--- a/.changeset/something-something.md
+++ b/.changeset/something-something.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-waffle": patch
+---
+
+Improve how errors are created in the hardhat-waffle plugin (#2307)

--- a/packages/hardhat-waffle/src/constants.ts
+++ b/packages/hardhat-waffle/src/constants.ts
@@ -1,0 +1,1 @@
+export const pluginName = "@nomiclabs/hardhat-waffle";

--- a/packages/hardhat-waffle/src/waffle-provider-adapter.ts
+++ b/packages/hardhat-waffle/src/waffle-provider-adapter.ts
@@ -1,6 +1,8 @@
 import { providers, Wallet } from "ethers";
 import { normalizeHardhatNetworkAccountsConfig } from "hardhat/internal/core/providers/util";
 import { HardhatNetworkConfig, Network } from "hardhat/types";
+import { NomicLabsHardhatPluginError } from "hardhat/plugins";
+import { pluginName } from "./constants";
 
 // This class is an extension of hardhat-ethers' wrapper.
 // TODO: Export hardhat-ether's wrapper so this can be implemented like a normal
@@ -12,8 +14,11 @@ export class WaffleMockProviderAdapter extends providers.JsonRpcProvider {
 
   public getWallets() {
     if (this._hardhatNetwork.name !== "hardhat") {
-      throw new Error(`This method only works with Hardhat Network.
-You can use \`await hre.ethers.getSigners()\` in other networks.`);
+      throw new NomicLabsHardhatPluginError(
+        pluginName,
+        `This method only works with Hardhat Network.
+You can use \`await hre.ethers.getSigners()\` in other networks.`
+      );
     }
 
     const networkConfig = this._hardhatNetwork.config as HardhatNetworkConfig;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Fixes #724

> The getWallets method in waffle-provider-adapters.ts throws a plain Error instead of using a NomicLabsBuidlerPluginError.

This PR fixes the plain error handling. I assume that `NomicLabsHardhatPluginError` (class used to throw errors from *core* hardhat plugins) is meant to replace the plain error instead of `NomicLabsBuidlerPluginError` as described in the issue.
