### PR TITLE
Add artifacts extensibility support

### DIFF
--- a/packages/hardhat-truffle4/src/type-extensions.ts
+++ b/packages/hardhat-truffle4/src/type-extensions.ts
@@ -4,7 +4,7 @@ import "hardhat/types/runtime";
 
 declare module "hardhat/types/artifacts" {
   export interface Artifacts {
-    require: (name: string) => any;
+    require(name: string): any;
   }
 }
 declare module "hardhat/types/runtime" {

--- a/packages/hardhat-truffle4/test/types.ts
+++ b/packages/hardhat-truffle4/test/types.ts
@@ -1,0 +1,25 @@
+import {artifacts} from "hardhat";
+
+type Dummy = unknown;
+
+type IERC20Contract = Dummy;
+
+type Equals<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends
+    (<T>() => T extends Y ? 1 : 2) ? true : false;
+
+type Assert<_X extends true> = void;
+
+// assert Artifacts can be extended
+
+declare module "hardhat/types/artifacts" {
+  export interface Artifacts {
+    require(name: 'IERC20'): IERC20Contract;
+  }
+}
+
+const ierc20Artifact = artifacts.require('IERC20');
+const unknownArtifact = artifacts.require('UnknownArtifact');
+
+export type Assert_IERC20_Type_Is_NotAny = Assert<Equals<IERC20Contract, typeof ierc20Artifact>>;
+export type Assert_UnknownArtifact_Type_Is_Any = Assert<Equals<any, typeof unknownArtifact>>;

--- a/packages/hardhat-truffle5/src/type-extensions.ts
+++ b/packages/hardhat-truffle5/src/type-extensions.ts
@@ -4,7 +4,7 @@ import "hardhat/types/runtime";
 
 declare module "hardhat/types/artifacts" {
   export interface Artifacts {
-    require: (name: string) => any;
+    require(name: string): any;
   }
 }
 

--- a/packages/hardhat-truffle5/test/types.ts
+++ b/packages/hardhat-truffle5/test/types.ts
@@ -1,0 +1,25 @@
+import {artifacts} from "hardhat";
+
+type Dummy = unknown;
+
+type IERC20Contract = Dummy;
+
+type Equals<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends
+    (<T>() => T extends Y ? 1 : 2) ? true : false;
+
+type Assert<_X extends true> = void;
+
+// assert Artifacts can be extended
+
+declare module "hardhat/types/artifacts" {
+  export interface Artifacts {
+    require(name: 'IERC20'): IERC20Contract;
+  }
+}
+
+const ierc20Artifact = artifacts.require('IERC20');
+const unknownArtifact = artifacts.require('UnknownArtifact');
+
+export type Assert_IERC20_Type_Is_NotAny = Assert<Equals<IERC20Contract, typeof ierc20Artifact>>;
+export type Assert_UnknownArtifact_Type_Is_Any = Assert<Equals<any, typeof unknownArtifact>>;


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

I hit this today when I was trying to make it work well with `TypeChain`. The problem is that current declaration can't be extended. Imagine you would like to augment `artifacts` with knowledge that it has some `IERC20` artifact which corresponds to an interface. It won't work today:

```ts 
declare module "hardhat/types/artifacts" {
    interface Artifacts {
        require(name: "IERC20"): IERC20Contract; // Duplicate identifier 'require'.ts(2300)
        // or
        require: (name: "IERC20") => IERC20Contract; // Subsequent property declarations must have the same type.  Property 'require' must be of type '(name: string) => any', but here has type '(name: "IERC20") => IERC20Contract'.ts(2717)
    }
}
```

But if we change it the way I propose it will work, and users will have a nice help from compiler and type inference:

